### PR TITLE
Edited README.md to include wiki info, game info, license 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # arch-enemies | because fighting is harmful
 
-> Buckle up gamer ( we've got a city to burn).
+> Buckle up gamer (we've got a city to burn).
 
 ---
 
 ## Overview:
 This repository represents the work done by 10 students aiming to programm their first game using GODOT.
-It allows for insights of struggles that we've had throughout development and will hopefully contain a playable game at the end of this semester ( early 2024 ).
+It allows for insights of struggles that we've had throughout development and will hopefully contain a playable game at the end of this semester (early 2024).
 
 ## Structure: 
 
 Everything regarding **concepts**, **ideas** or **protocols** is to be found in [the docs](/docs/)
+For more information on Game Design and Implementation (?) see [the Wiki](https://github.com/mango-gremlin/arch-enemies/wiki)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 > Buckle up gamer (we've got a city to burn).
 
+![bridge-scene_biig](https://github.com/mango-gremlin/arch-enemies/assets/104830903/5d81c995-cb1e-4c41-a64c-37310515f3bb)
+
+Arch Enemies is a combat-bridge building game where a fox tries to bridge the differences of the animals in the forest to save their home from invasive species. It involves convincing other animals to join your cause, building bridges by solving puzzles, using your allies to cross a flooded forest, and fighting an army of invasive animals in card-based combat.
+
 ---
 
 ## Overview:
@@ -11,4 +15,44 @@ It allows for insights of struggles that we've had throughout development and wi
 ## Structure: 
 
 Everything regarding **concepts**, **ideas** or **protocols** is to be found in [the docs](/docs/)
-For more information on Game Design and Implementation (?) see [the Wiki](https://github.com/mango-gremlin/arch-enemies/wiki)
+For more information on Game Design and Implementation, as well as more details for the game's story, see [the Wiki](https://github.com/mango-gremlin/arch-enemies/wiki)
+
+---
+
+## How to run the game
+~ watch this space ~
+
+---
+
+## Contributing
+
+### How to submit issues
+-> guide on how to make a bug report? -> maybe irrelevant but still nice to have in there, add this in time
+
+---
+
+## Licensing
+We are using an MIT License for this game. For more information, see [here](https://github.com/mango-gremlin/arch-enemies/blob/d390d485051dfb2a5ab55d9eb6f97ea2c08d81c3/LICENSE).
+
+## Credits
+
+### Assets
+- Raffael Rack
+- Katja Bochinak
+- Mara Cockburn
+- to be expanded later
+
+### Libraries
+
+### Game Engine
+This game uses Godot Engine, available under the following license:
+
+Copyright (c) 2014-present Godot Engine contributors. Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://docs.godotengine.org/en/latest/about/complying_with_licenses.html


### PR DESCRIPTION
## Motivation
Make people aware we have a wiki. Use the wiki.

## What was changed/added
I added a link to the wiki to the readme - ALSO: What exactly are we going to put in the readme? 

**Proposals:**
1. Game Design Finalised Ideas that will serve as guide to implementation (so we have everything in one place)
2. How we want to implement things / guide & documentation to implementation? (or should that stay in the docs?)
3. What else?

Please let me know what you think, multiple things can also work. I think 1 and 2 would both be very helpful, maybe we can split the wiki up a little bit?

---

### Added after comments:
- a banner with the arch-enemy front image ( acting as opening for the github-page)
- short context ( who we are, what we work on )
- Overview of game ( short summary of what this game is about, maybe 3-4 sentences at most? )
- some screenshots ( ofc not yet, we dont have any :D )
- How to run / execute ( ofc not usable yet but giving an example of how to set up the environment )
-  where and how to submit issues (? we wont have much traffic so maybe a little irrelevant)
- used license
- resource / src of assets, libraries used etc ( crediting them accordingly )

