### PR TITLE
add general dropzones on all sides of the snake

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -2,23 +2,18 @@ extends StaticBody2D
 
 var draggable = false
 var is_inside_dropable = false
-var dropzone_left
-var original_pos_dropzone_left
+var dropzone
+var original_pos_dropzone
 var offset : Vector2
 var initial_pos : Vector2
 var is_dragging = false
 var inside_object = false
-var dropzone_left_occupied = false
+var dropzone_occupied = false
 
-func _process(delta):
+func _process(_delta):
 	if draggable:
 		
-		if dropzone_left == null or original_pos_dropzone_left == null:
-			# THIS HAS SO MANY BUGS BUT THEY ARE NOT RELEVANT NOW
-			# this part initialises the positions, but it doesnt really work
-			# exactly as intended
-			self.dropzone_left = self.get_children()[2]
-			self.original_pos_dropzone_left = self.dropzone_left.global_position
+		#initialize_dropzones()
 		
 		if Input.is_action_just_pressed("click"):
 			# will ensure the object follows mouse at begin of click
@@ -50,11 +45,9 @@ func _process(delta):
 				# dragged object ends up in the right place
 				
 				# save original position of dropable zone
-				#self.original_pos_dropzone_left = self.dropzone_left.global_position
-				
-				# shift the position so it snaps perfectly to the side
+				#self.original_pos_dropzone = self.dropzone_.global_position
 				# not buggy, unless snakes touch each other, probably
-				var drop_area = Vector2(self.dropzone_left.global_position.x - (59/2) + (7/2), self.dropzone_left.global_position.y)
+				var drop_area = calculate_droparea(self.dropzone)
 				
 				# if we can drop this here, play animation with the 
 				# final position being the position of the dropable zone
@@ -63,7 +56,7 @@ func _process(delta):
 				# if dropzone WAS occupied but we switched to something else it is
 				# no longer occupied
 				# if it wasnt, then now we switched to it and it is occupied
-				self.dropzone_left_occupied = not self.dropzone_left_occupied
+				self.dropzone_occupied = not self.dropzone_occupied
 		
 			else:
 				# if we cannot drop it here, let it snap back to its original position
@@ -90,7 +83,7 @@ func _on_snake_body_entered(body):
 	if body.is_in_group('dropable'):
 		is_inside_dropable = true
 		body.modulate = Color(Color.CORNFLOWER_BLUE, 1)
-		self.dropzone_left = body
+		self.dropzone = body
 		
 
 func _on_snake_body_exited(body):
@@ -100,4 +93,20 @@ func _on_snake_body_exited(body):
 		is_inside_dropable = false
 		body.modulate = Color(Color.AQUAMARINE, 0.7)
 
-		#self.dropzone_left.global_position = self.original_pos_dropzone_left
+#func initialize_dropzones():
+#	if dropzone == null or original_pos_dropzone == null:
+			# THIS HAS SO MANY BUGS BUT THEY ARE NOT RELEVANT NOW
+			# this part initialises the positions, but it doesnt really work
+			# exactly as intended
+#			self.dropzone = self.get_children()[2]
+#			self.original_pos_dropzone = self.dropzone.global_position
+
+func calculate_droparea(body):
+	# returns the new position of where to place the animal in relation to the dropzone,
+	# because right now, the anchor point is in the middle of a body
+	if body.is_in_group('left_dropzone'):
+		return Vector2(self.dropzone.global_position.x - (59.0/2) + (7.0/2), self.dropzone.global_position.y)
+	if body.is_in_group('top_dropzone'):
+		return Vector2(self.dropzone.global_position.x - 13, self.dropzone.global_position.y - 13)
+	if body.is_in_group('bottom_dropzone'):
+		return Vector2(self.dropzone.global_position.x - 13, self.dropzone.global_position.y + 13)

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/ModeChangeButton.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/ModeChangeButton.gd
@@ -1,7 +1,7 @@
 extends CheckButton
 
 
-func _on_toggled(button_pressed):
+func _on_toggled(_button_pressed):
 	if not Global.drag_mode:
 		Global.drag_mode = true
 		self.text = "drag mode"

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/allowed_snake_area.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/allowed_snake_area.gd
@@ -6,7 +6,7 @@ func _ready():
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _process(_delta):
 	if Global.something_is_being_dragged && self.get_parent().get_name() != Global.currently_dragging:
 		visible = true
 	else:

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/fox.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/fox.gd
@@ -37,6 +37,6 @@ func reset_fox():
 	velocity.y = 0
 	global_position = Vector2(74, 111)
 
-func _on_area_2d_body_entered(body):
+func _on_area_2d_body_entered(_body):
 	# if fox touches water
 	reset_fox()

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/snek.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/snek.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://c5tl3m10s5tby"]
+[gd_scene load_steps=9 format=3 uid="uid://c5tl3m10s5tby"]
 
 [ext_resource type="Texture2D" uid="uid://47bt3n56d3fc" path="res://assets/box_snake.png" id="1_c08hy"]
 [ext_resource type="Script" path="res://DragObject.gd" id="1_gtwqh"]
@@ -12,6 +12,12 @@ size = Vector2(57, 12.5)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_lyvfn"]
 size = Vector2(7, 14)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_f3mbg"]
+size = Vector2(46, 9)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_f6euc"]
+size = Vector2(46, 10)
 
 [node name="snakeBod" type="StaticBody2D" groups=["draggable"]]
 script = ExtResource("1_gtwqh")
@@ -27,20 +33,48 @@ shape = SubResource("RectangleShape2D_43xhd")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="snake"]
 shape = SubResource("RectangleShape2D_i2o3k")
 
-[node name="allowed_snake_area" type="StaticBody2D" parent="." groups=["dropable"]]
+[node name="left_dropzone" type="StaticBody2D" parent="." groups=["dropable", "left_dropzone"]]
 position = Vector2(-33, 0)
 script = ExtResource("3_fqrgl")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="allowed_snake_area"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone"]
 shape = SubResource("RectangleShape2D_lyvfn")
 
-[node name="ColorRect" type="ColorRect" parent="allowed_snake_area"]
+[node name="ColorRect" type="ColorRect" parent="left_dropzone"]
 z_index = -1
 offset_left = -3.0
 offset_top = -7.0
 offset_right = 4.0
 offset_bottom = 7.0
 metadata/_edit_use_anchors_ = true
+
+[node name="top_dropzone" type="StaticBody2D" parent="." groups=["dropable", "top_dropzone"]]
+script = ExtResource("3_fqrgl")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
+position = Vector2(-6, -11)
+shape = SubResource("RectangleShape2D_f3mbg")
+
+[node name="ColorRect" type="ColorRect" parent="top_dropzone"]
+z_index = -1
+offset_left = -29.0
+offset_top = -15.0
+offset_right = 17.0
+offset_bottom = -6.0
+
+[node name="bottom_dropzone" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
+script = ExtResource("3_fqrgl")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]
+position = Vector2(-6, 12)
+shape = SubResource("RectangleShape2D_f6euc")
+
+[node name="ColorRect" type="ColorRect" parent="bottom_dropzone"]
+z_index = -1
+offset_left = -29.0
+offset_top = 6.0
+offset_right = 16.0
+offset_bottom = 16.0
 
 [connection signal="body_entered" from="snake" to="." method="_on_snake_body_entered"]
 [connection signal="body_exited" from="snake" to="." method="_on_snake_body_exited"]


### PR DESCRIPTION
## Motivation
closes issue #30

The snake has now dropzones on all sides, excluding the head. The code was also refactored to make adding more dropzones as simple as possible.

## What was changed/added
Added dropzones (StaticBody2D with CollisionBody2D and ColorRect) manually, connected it with the allowed_snake_area script and added the neccessary "dropable" and "left/top/bottom_dropzone" groups for identification.
In DragObject.gd, all variables for the left dropzone were changed to general dropzone variables and the function "calculate_dropzones" was added to calculate the new snapping position depending on the dropzone.

I also fixed all those annoying warnings (mainly unused parameters in functions).

## Testing

https://github.com/mango-gremlin/arch-enemies/assets/57258671/e8416f63-ad1c-4e09-9e98-7c40b8b224fd


## Bugs
While it does work, hitting different dropzones too fast or hovering over the body of the snake results in unexpected results.
This will be partially solved in issue #35.