### PR TITLE
Disabled dragging in fox mode

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -11,7 +11,7 @@ var inside_object = false
 var dropzone_left_occupied = false
 
 func _process(delta):
-	if draggable:
+	if draggable && Global.drag_mode == true:
 		
 		if dropzone_left == null or original_pos_dropzone_left == null:
 			# THIS HAS SO MANY BUGS BUT THEY ARE NOT RELEVANT NOW
@@ -72,7 +72,7 @@ func _process(delta):
 func _on_area_2d_mouse_entered():
 	# if the mouse enters the area and we are not currently dragging this object
 	# set this to draggable
-	if not self.is_dragging:
+	if not self.is_dragging && Global.drag_mode == true:
 		self.draggable = true
 		self.scale = Vector2(1.05, 1.05)
 

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/project.godot
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/project.godot
@@ -23,6 +23,10 @@ Global="*res://global.gd"
 
 window/stretch/scale=2.0
 
+[dotnet]
+
+project/assembly_name="Bridge_Prototype_1.3"
+
 [input]
 
 ui_accept={


### PR DESCRIPTION
## Motivation
closes #28 

Previously it was possible to drag the snakes while in fox mode. We want the player to switch between the bridge building and the bridge crossing, so that had to change.

## What was changed/added

I added a condition requiring drag mode to be true to the dragging function and the mouse-over highlight function.

## Testing

I tested the change in the Godot debug mode:
https://github.com/mango-gremlin/arch-enemies/assets/116198748/c092cb91-852b-49a5-bee3-49d3728003d8

## Additional Information
The changes are built onto the base project Prototype_Bridges_1.3
