### PR TITLE
added grid snap functionality after releasing snake

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -9,10 +9,10 @@ var initial_pos : Vector2
 var is_dragging = false
 var inside_object = false
 var dropzone_left_occupied = false
+var grid_size : float = 10.0 # size of a square in grid
 
 func _process(delta):
 	if draggable:
-		
 		if dropzone_left == null or original_pos_dropzone_left == null:
 			# THIS HAS SO MANY BUGS BUT THEY ARE NOT RELEVANT NOW
 			# this part initialises the positions, but it doesnt really work
@@ -36,6 +36,10 @@ func _process(delta):
 			
 		elif Input.is_action_just_released("click"):
 			# when click is released:
+			
+			# snap to nearest position in grid
+			self.position.x =  round_to_nearest(self.position.x, grid_size)
+			self.position.y = round_to_nearest(self.position.y, grid_size)
 			
 			# 1. nothing is being currently dragged
 			self.is_dragging = false
@@ -91,7 +95,6 @@ func _on_snake_body_entered(body):
 		is_inside_dropable = true
 		body.modulate = Color(Color.CORNFLOWER_BLUE, 1)
 		self.dropzone_left = body
-		
 
 func _on_snake_body_exited(body):
 	# if the snake body stops touching a staticbody that has the dropable group
@@ -101,3 +104,11 @@ func _on_snake_body_exited(body):
 		body.modulate = Color(Color.AQUAMARINE, 0.7)
 
 		#self.dropzone_left.global_position = self.original_pos_dropzone_left
+
+# rounds to nearest multiple of b to a
+func round_to_nearest(a:float, b:float):
+	var offset = fmod(a,b)
+	if offset < b:
+		return a - offset
+	else:
+		return a + (b - offset) 

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -108,7 +108,7 @@ func _on_snake_body_exited(body):
 # rounds to nearest multiple of b to a
 func round_to_nearest(a:float, b:float):
 	var offset = fmod(a,b)
-	if offset < b:
+	if offset < b / 2:
 		return a - offset
 	else:
 		return a + (b - offset) 

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
@@ -97,10 +97,10 @@ SPEED = 150.0
 JUMP_VELOCITY = -200.0
 
 [node name="snek" parent="." instance=ExtResource("3_0bug4")]
-position = Vector2(179, 115)
+position = Vector2(180, 110)
 
 [node name="snek2" parent="." instance=ExtResource("3_0bug4")]
-position = Vector2(298, 131)
+position = Vector2(300, 130)
 
 [node name="DragModeButton" type="CheckButton" parent="."]
 offset_left = 208.0


### PR DESCRIPTION
## Motivation
closes #32 

## What was changed/added
Dragged snake now snaps to nearest position within grid after releasing the click button, before considering if it is within a placeable zone or not. Currently a grid square size of 10x10 pixels is assumed, this can be changed via the ``grid_size`` variable. Getting the nearest grid square is done using the ``round_to_nearest(a:float, b:float)`` function. 

Also, initial placements of snakes has been adjusted to the 10x10 grid.

## Testing
The effect is barely noticable, as it occurs in the same frame as the snapping to droppable/return to original position. Using print statements, however, confirms the functionality of the code (not included in commit, but printing ``self.position`` before and after the snap can be tested).

![image](https://github.com/mango-gremlin/arch-enemies/assets/104799849/60180ed2-9c67-42c3-bc7f-7ae3dd39a73a)

## Discussion
Adds the helper function ``round_to_nearest(a:float, b:float)``, which may be helpful elsewhere. It may also be beneficial to put all helper functions in an external file.

