### PR TITLE
Added goal area and victory screen which you can restart the level from

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/fox.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/fox.gd
@@ -40,3 +40,8 @@ func reset_fox():
 func _on_area_2d_body_entered(_body):
 	# if fox touches water
 	reset_fox()
+
+
+
+func _on_goal_area_2d_body_entered(_body):
+	get_parent().get_node("GoalMenu").visible = true

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/goal_menu.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/goal_menu.gd
@@ -1,0 +1,21 @@
+extends Control
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(_delta):
+	pass
+
+
+func _on_retry_button_pressed():
+	get_parent().get_node("fox").reset_fox()
+	visible = false
+
+
+func _on_continue_button_pressed():
+	print("lets go to the overworld now")
+	

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/goal_menu.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/goal_menu.tscn
@@ -1,0 +1,52 @@
+[gd_scene load_steps=2 format=3 uid="uid://cxj1q08s3i7i8"]
+
+[ext_resource type="Script" path="res://goal_menu.gd" id="1_e6stn"]
+
+[node name="GoalMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_e6stn")
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -125.0
+offset_top = -56.0
+offset_right = 125.0
+offset_bottom = 56.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Label" type="Label" parent="Panel/VBoxContainer"]
+layout_mode = 2
+text = "Success!"
+horizontal_alignment = 1
+
+[node name="ContinueButton" type="Button" parent="Panel/VBoxContainer"]
+layout_mode = 2
+text = "Continue"
+
+[node name="RetryButton" type="Button" parent="Panel/VBoxContainer"]
+layout_mode = 2
+text = "Retry"
+
+[connection signal="pressed" from="Panel/VBoxContainer/ContinueButton" to="." method="_on_continue_button_pressed"]
+[connection signal="pressed" from="Panel/VBoxContainer/RetryButton" to="." method="_on_retry_button_pressed"]

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=12 format=3 uid="uid://cf5udd6l65fuv"]
+[gd_scene load_steps=15 format=3 uid="uid://cf5udd6l65fuv"]
 
 [ext_resource type="Texture2D" uid="uid://d4khq8o7aaei" path="res://assets/green.png" id="1_m0btg"]
 [ext_resource type="Texture2D" uid="uid://dc2lxeyr45vp3" path="res://assets/blue_dark.png" id="2_640fj"]
 [ext_resource type="PackedScene" uid="uid://dvgr170gyuhpq" path="res://fox.tscn" id="2_u7ijr"]
 [ext_resource type="PackedScene" uid="uid://c5tl3m10s5tby" path="res://snek.tscn" id="3_0bug4"]
 [ext_resource type="Script" path="res://ModeChangeButton.gd" id="6_8qx0u"]
+[ext_resource type="PackedScene" uid="uid://cxj1q08s3i7i8" path="res://goal_menu.tscn" id="6_xdjb3"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_s2tkw"]
 texture = ExtResource("1_m0btg")
@@ -47,6 +48,9 @@ terrain_set_0/mode = 0
 sources/0 = SubResource("TileSetAtlasSource_s2tkw")
 sources/1 = SubResource("TileSetAtlasSource_udipr")
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_3avum"]
+size = Vector2(63, 59.75)
+
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_vsiy0"]
 texture = ExtResource("2_640fj")
 0:0/0 = 0
@@ -70,6 +74,30 @@ sources/0 = SubResource("TileSetAtlasSource_vsiy0")
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_6rkrv"]
 size = Vector2(345, 54)
 
+[sub_resource type="GDScript" id="GDScript_62t5p"]
+script/source = "extends Control
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(_delta):
+	pass
+
+
+func _on_retry_button_pressed():
+	get_parent().get_node(\"fox\").reset_fox()
+	visible = false
+
+
+func _on_continue_button_pressed():
+	print(\"lets go to the overworld now\")
+	
+"
+
 [node name="Node2D" type="Node2D"]
 
 [node name="TileMap" type="TileMap" parent="."]
@@ -77,6 +105,13 @@ position = Vector2(47, 101)
 tile_set = SubResource("TileSet_rwph5")
 format = 2
 layer_0/tile_data = PackedInt32Array(262143, 0, 0, 196608, 0, 0, 196609, 0, 0, 196610, 0, 0, 196611, 0, 0, 262147, 0, 0, 327683, 0, 0, 393219, 0, 0, 458755, 0, 0, 524291, 0, 0, 589827, 0, 0, 589828, 0, 0, 589829, 0, 0, 589830, 0, 0, 589831, 0, 0, 589832, 0, 0, 589833, 0, 0, 589834, 0, 0, 589835, 0, 0, 589836, 0, 0, 589837, 0, 0, 589838, 0, 0, 589839, 0, 0, 589840, 0, 0, 327678, 0, 0, 393214, 0, 0, 458750, 0, 0, 524287, 0, 0, 589823, 0, 0, 655359, 0, 0, 720895, 0, 0, 786431, 0, 0, 851967, 0, 0, 786432, 0, 0, 786433, 0, 0, 786434, 0, 0, 786435, 0, 0, 786436, 0, 0, 786437, 0, 0, 786438, 0, 0, 786439, 0, 0, 786440, 0, 0, 786441, 0, 0, 720906, 0, 0, 720907, 0, 0, 720908, 0, 0, 720909, 0, 0, 720910, 0, 0, 720911, 0, 0, 720912, 0, 0, 655377, 0, 0, 655378, 0, 0, 655379, 0, 0, 655380, 0, 0, 589844, 0, 0, 524286, 0, 0, 589822, 0, 0, 655358, 0, 0, 720894, 0, 0, 786430, 0, 0, 851966, 0, 0, 786442, 0, 0, 786443, 0, 0, 786444, 0, 0, 786445, 0, 0, 720913, 0, 0, 720914, 0, 0, 720915, 0, 0, 720916, 0, 0, 786452, 0, 0, 786451, 0, 0, 786450, 0, 0, 786449, 0, 0, 786448, 0, 0, 786447, 0, 0, 786446, 0, 0, 720898, 0, 0, 655362, 0, 0, 589826, 0, 0, 524290, 0, 0, 458754, 0, 0, 393218, 0, 0, 327682, 0, 0, 262146, 0, 0, 262145, 0, 0, 262144, 0, 0, 327679, 0, 0, 393215, 0, 0, 458751, 0, 0, 393216, 0, 0, 327680, 0, 0, 327681, 0, 0, 393217, 0, 0, 458753, 0, 0, 458752, 0, 0, 524288, 0, 0, 589824, 0, 0, 655360, 0, 0, 720896, 0, 0, 720897, 0, 0, 655361, 0, 0, 589825, 0, 0, 524289, 0, 0, 655363, 0, 0, 720899, 0, 0, 720900, 0, 0, 655364, 0, 0, 655365, 0, 0, 720901, 0, 0, 720902, 0, 0, 655366, 0, 0, 655367, 0, 0, 720903, 0, 0, 720904, 0, 0, 655368, 0, 0, 655369, 0, 0, 720905, 0, 0, 655370, 0, 0, 655371, 0, 0, 655372, 0, 0, 655373, 0, 0, 655374, 0, 0, 655375, 0, 0, 655376, 0, 0, 589841, 0, 0, 589842, 0, 0, 589843, 0, 0, 786453, 0, 0, 720917, 0, 0, 655381, 0, 0, 589845, 0, 0, 589846, 0, 0, 589847, 0, 0, 524311, 0, 0, 458775, 0, 0, 393239, 0, 0, 393240, 0, 0, 327704, 0, 0, 262168, 0, 0, 262169, 0, 0, 262170, 0, 0, 196634, 0, 0, 131098, 0, 0, 131099, 0, 0, 131100, 0, 0, 131101, 0, 0, 196637, 0, 0, 262173, 0, 0, 327709, 0, 0, 393245, 0, 0, 458781, 0, 0, 524317, 0, 0, 589853, 0, 0, 655389, 0, 0, 720925, 0, 0, 786460, 0, 0, 786459, 0, 0, 786458, 0, 0, 786457, 0, 0, 786456, 0, 0, 786455, 0, 0, 786454, 0, 0, 720918, 0, 0, 655382, 0, 0, 524310, 0, 0, 589848, 0, 0, 655384, 0, 0, 720920, 0, 0, 720919, 0, 0, 524312, 0, 0, 524313, 0, 0, 589849, 0, 0, 655385, 0, 0, 720921, 0, 0, 655383, 0, 0, 458776, 0, 0, 458777, 0, 0, 458778, 0, 0, 393241, 0, 0, 393242, 0, 0, 393243, 0, 0, 458780, 0, 0, 458779, 0, 0, 524315, 0, 0, 327706, 0, 0, 327705, 0, 0, 327707, 0, 0, 327708, 0, 0, 262172, 0, 0, 262171, 0, 0, 196635, 0, 0, 196636, 0, 0, 393244, 0, 0, 524316, 0, 0, 589852, 0, 0, 655388, 0, 0, 720924, 0, 0, 720923, 0, 0, 524314, 0, 0, 589850, 0, 0, 589851, 0, 0, 655387, 0, 0, 720922, 0, 0, 655386, 0, 0)
+
+[node name="GoalArea2D" type="Area2D" parent="TileMap"]
+
+[node name="GoalCollisionShape2D" type="CollisionShape2D" parent="TileMap/GoalArea2D"]
+position = Vector2(448, 1.875)
+shape = SubResource("RectangleShape2D_3avum")
+debug_color = Color(0.521569, 0.560784, 0.341176, 0.419608)
 
 [node name="water" type="TileMap" parent="."]
 position = Vector2(-35, 21)
@@ -112,5 +147,14 @@ alignment = 1
 icon_alignment = 1
 script = ExtResource("6_8qx0u")
 
+[node name="GoalMenu" parent="." instance=ExtResource("6_xdjb3")]
+visible = false
+top_level = true
+anchors_preset = -1
+offset_right = 3.0
+offset_bottom = -1.0
+script = SubResource("GDScript_62t5p")
+
+[connection signal="body_entered" from="TileMap/GoalArea2D" to="fox" method="_on_goal_area_2d_body_entered"]
 [connection signal="body_entered" from="water/Area2D" to="fox" method="_on_area_2d_body_entered"]
 [connection signal="toggled" from="DragModeButton" to="DragModeButton" method="_on_toggled"]


### PR DESCRIPTION
## Motivation
closes #36 

We wanted the player to be able to reach the goal and finish the bridge-level.

## What was changed/added
Added a collision box for the goal and a victory screen / goal menu to display when entered by the player.
From the goal menu you can restart the level (reset the fox to the starting position) or in the future be able to continue to the overworld. 

## Testing
Feature works as intended during testing.
![grafik](https://github.com/mango-gremlin/arch-enemies/assets/116217918/e3119a7a-308c-47b3-a189-0e505e2002ac)

## Additional Information
The continue (to the overworld) button exists but is non-functional as of know. The transition to the overworld scene needs to be implemented in the future.
