### PR TITLE
Fixed: dragged object should be on top level

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -19,6 +19,9 @@ func _process(_delta):
 		
 		#initialize_dropzones()
 		if Input.is_action_just_pressed("click"):
+			# dragged object should be on top level
+			self.top_level = true
+			
 			# will ensure the object follows mouse at begin of click
 			self.initial_pos = self.global_position
 			
@@ -34,6 +37,9 @@ func _process(_delta):
 			
 		elif Input.is_action_just_released("click"):
 			# when click is released:
+			
+			# dropped object should not be on top level anymore
+			self.top_level = false
 			
 			# snap to nearest position in grid
 			self.position.x =  round_to_nearest(self.position.x, grid_size)


### PR DESCRIPTION
## Motivation
closes #67

When picking up the object (e.g. a snake) it might be displayed behind other objects. To make the currently dragged object more visible and stand out more it should always be displayed on top of everything else.

## What was changed/added
In DragObject.gd the top_level of the dragged object will be set to true if the action is just pressed and it will be set to false if the action is just released.

## Testing

https://github.com/mango-gremlin/arch-enemies/assets/116217918/44772f8c-ab2a-4366-bff7-158e2c134668

