### PR TITLE
Fixed Dropbox collision bug

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/project.godot
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/project.godot
@@ -56,6 +56,11 @@ jump={
 ]
 }
 
+[layer_names]
+
+2d_physics/layer_1="collision"
+2d_physics/layer_2="droppable"
+
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/snek.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/snek.tscn
@@ -20,6 +20,8 @@ size = Vector2(10, 10)
 size = Vector2(10, 10)
 
 [node name="snakeBod" type="StaticBody2D" groups=["draggable"]]
+collision_layer = 3
+collision_mask = 3
 script = ExtResource("1_gtwqh")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
@@ -29,12 +31,16 @@ texture = ExtResource("1_c08hy")
 shape = SubResource("RectangleShape2D_43xhd")
 
 [node name="snake" type="Area2D" parent="."]
+collision_layer = 3
+collision_mask = 3
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="snake"]
 shape = SubResource("RectangleShape2D_i2o3k")
 
 [node name="left_dropzone" type="StaticBody2D" parent="." groups=["dropable", "left_dropzone"]]
 position = Vector2(-34, 0)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone"]
@@ -50,6 +56,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="top_dropzone" type="StaticBody2D" parent="." groups=["dropable", "top_dropzone"]]
 position = Vector2(-23, -11)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
@@ -65,6 +73,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="top_dropzone3" type="StaticBody2D" parent="." groups=["dropable", "top_dropzone"]]
 position = Vector2(-1, -11)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone3"]
@@ -80,6 +90,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="top_dropzone4" type="StaticBody2D" parent="." groups=["dropable", "top_dropzone"]]
 position = Vector2(10, -11)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone4"]
@@ -95,6 +107,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="top_dropzone2" type="StaticBody2D" parent="." groups=["dropable", "top_dropzone"]]
 position = Vector2(-12, -11)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone2"]
@@ -110,6 +124,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="bottom_dropzone" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
 position = Vector2(-23, 11)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]
@@ -125,6 +141,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="bottom_dropzone2" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
 position = Vector2(-12, 11)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone2"]
@@ -140,6 +158,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="bottom_dropzone3" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
 position = Vector2(-1, 11)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone3"]
@@ -155,6 +175,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="bottom_dropzone4" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
 position = Vector2(10, 11)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone4"]

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/squirrel.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/squirrel.tscn
@@ -14,6 +14,8 @@ size = Vector2(10, 22)
 size = Vector2(10, 10)
 
 [node name="squirrelBod" type="StaticBody2D" groups=["draggable"]]
+collision_layer = 3
+collision_mask = 3
 script = ExtResource("1_ss8yf")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
@@ -24,12 +26,16 @@ texture = ExtResource("2_eib8h")
 shape = SubResource("RectangleShape2D_m8jht")
 
 [node name="squirrel" type="Area2D" parent="."]
+collision_layer = 3
+collision_mask = 3
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="squirrel"]
 shape = SubResource("RectangleShape2D_4bimj")
 
 [node name="left_dropzone" type="StaticBody2D" parent="." groups=["dropable", "left_dropzone"]]
 position = Vector2(-11, 6)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone"]
@@ -45,6 +51,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="left_dropzone2" type="StaticBody2D" parent="." groups=["dropable", "left_dropzone"]]
 position = Vector2(-11, -6)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone2"]
@@ -60,6 +68,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="right_dropzone" type="StaticBody2D" parent="." groups=["dropable", "right_dropzone"]]
 position = Vector2(11, -6)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone"]
@@ -75,6 +85,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="right_dropzone2" type="StaticBody2D" parent="." groups=["dropable", "right_dropzone"]]
 position = Vector2(11, 6)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone2"]
@@ -90,6 +102,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="top_dropzone" type="StaticBody2D" parent="." groups=["dropable", "top_dropzone"]]
 position = Vector2(0, -17)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
@@ -105,6 +119,8 @@ metadata/_edit_use_anchors_ = true
 
 [node name="bottom_dropzone" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
 position = Vector2(0, 17)
+collision_layer = 2
+collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://cf5udd6l65fuv"]
+[gd_scene load_steps=17 format=3 uid="uid://cf5udd6l65fuv"]
 
 [ext_resource type="Texture2D" uid="uid://d4khq8o7aaei" path="res://assets/green.png" id="1_m0btg"]
 [ext_resource type="Texture2D" uid="uid://dc2lxeyr45vp3" path="res://assets/blue_dark.png" id="2_640fj"]
@@ -134,7 +134,7 @@ SPEED = 150.0
 JUMP_VELOCITY = -200.0
 
 [node name="snek" parent="." instance=ExtResource("3_0bug4")]
-position = Vector2(180, 110)
+position = Vector2(140, 154)
 
 [node name="snek2" parent="." instance=ExtResource("3_0bug4")]
 position = Vector2(300, 130)


### PR DESCRIPTION
## Motivation
closes #49
The Dropbox collision bug was a major bug prohibiting proper jump/run 

## What was changed
To fix the Bug all the dropboxes are now on Physics layer two. The main snake collision box now is on both Physics layer one and two. 

In the main document the Physics layer one and two have been renamed to showcases their purpose.

## Testing

![fox_is_not_bugged](https://github.com/mango-gremlin/arch-enemies/assets/65815628/ade4e924-45d2-4e09-9212-f1624b637fb0)

## Additional Notes
The behavior and drag and drop feels very janky. It behaves the same as before as far as I can tell and test, but I cannot guarantee that the behavior hasn't changed in some edge cases.

Resolves https://github.com/mango-gremlin/arch-enemies/issues/49