### PR TITLE
added multible drop zones to the shore and a new Group: right_dropzone

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -114,6 +114,8 @@ func calculate_droparea(body):
 	# because right now, the anchor point is in the middle of a body
 	if body.is_in_group('left_dropzone'):
 		return Vector2(self.dropzone.global_position.x - (59.0/2) + (7.0/2), self.dropzone.global_position.y)
+	if body.is_in_group('right_dropzone'):
+		return Vector2(self.dropzone.global_position.x + (59.0/2) + (7.0/2) - 6, self.dropzone.global_position.y)
 	if body.is_in_group('top_dropzone'):
 		return Vector2(self.dropzone.global_position.x - 13, self.dropzone.global_position.y - 13)
 	if body.is_in_group('bottom_dropzone'):

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://cf5udd6l65fuv"]
+[gd_scene load_steps=17 format=3 uid="uid://cf5udd6l65fuv"]
 
 [ext_resource type="Texture2D" uid="uid://d4khq8o7aaei" path="res://assets/green.png" id="1_m0btg"]
 [ext_resource type="Texture2D" uid="uid://dc2lxeyr45vp3" path="res://assets/blue_dark.png" id="2_640fj"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://c5tl3m10s5tby" path="res://snek.tscn" id="3_0bug4"]
 [ext_resource type="Script" path="res://ModeChangeButton.gd" id="6_8qx0u"]
 [ext_resource type="PackedScene" uid="uid://cxj1q08s3i7i8" path="res://goal_menu.tscn" id="6_xdjb3"]
+[ext_resource type="Script" path="res://allowed_snake_area.gd" id="7_x2i8d"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_s2tkw"]
 texture = ExtResource("1_m0btg")
@@ -98,6 +99,9 @@ func _on_continue_button_pressed():
 	
 "
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_7nrdv"]
+size = Vector2(7, 14)
+
 [node name="Node2D" type="Node2D"]
 
 [node name="TileMap" type="TileMap" parent="."]
@@ -132,7 +136,7 @@ SPEED = 150.0
 JUMP_VELOCITY = -200.0
 
 [node name="snek" parent="." instance=ExtResource("3_0bug4")]
-position = Vector2(180, 110)
+position = Vector2(171, 114)
 
 [node name="snek2" parent="." instance=ExtResource("3_0bug4")]
 position = Vector2(300, 130)
@@ -154,6 +158,81 @@ anchors_preset = -1
 offset_right = 3.0
 offset_bottom = -1.0
 script = SubResource("GDScript_62t5p")
+
+[node name="right_dropzone" type="StaticBody2D" parent="." groups=["dropable", "right_dropzone"]]
+position = Vector2(107, 142)
+script = ExtResource("7_x2i8d")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone"]
+shape = SubResource("RectangleShape2D_7nrdv")
+
+[node name="ColorRect" type="ColorRect" parent="right_dropzone"]
+z_index = -1
+offset_left = -3.0
+offset_top = -7.0
+offset_right = 4.0
+offset_bottom = 7.0
+metadata/_edit_use_anchors_ = true
+
+[node name="right_dropzone2" type="StaticBody2D" parent="." groups=["dropable", "right_dropzone"]]
+position = Vector2(100, 142)
+script = ExtResource("7_x2i8d")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone2"]
+shape = SubResource("RectangleShape2D_7nrdv")
+
+[node name="ColorRect" type="ColorRect" parent="right_dropzone2"]
+z_index = -1
+offset_left = -3.0
+offset_top = -7.0
+offset_right = 4.0
+offset_bottom = 7.0
+metadata/_edit_use_anchors_ = true
+
+[node name="right_dropzone3" type="StaticBody2D" parent="." groups=["dropable", "right_dropzone"]]
+position = Vector2(93, 142)
+script = ExtResource("7_x2i8d")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone3"]
+shape = SubResource("RectangleShape2D_7nrdv")
+
+[node name="ColorRect" type="ColorRect" parent="right_dropzone3"]
+z_index = -1
+offset_left = -3.0
+offset_top = -7.0
+offset_right = 4.0
+offset_bottom = 7.0
+metadata/_edit_use_anchors_ = true
+
+[node name="right_dropzone4" type="StaticBody2D" parent="." groups=["dropable", "right_dropzone"]]
+position = Vector2(86, 142)
+script = ExtResource("7_x2i8d")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone4"]
+shape = SubResource("RectangleShape2D_7nrdv")
+
+[node name="ColorRect" type="ColorRect" parent="right_dropzone4"]
+z_index = -1
+offset_left = -3.0
+offset_top = -7.0
+offset_right = 4.0
+offset_bottom = 7.0
+metadata/_edit_use_anchors_ = true
+
+[node name="right_dropzone5" type="StaticBody2D" parent="." groups=["dropable", "right_dropzone"]]
+position = Vector2(79, 142)
+script = ExtResource("7_x2i8d")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone5"]
+shape = SubResource("RectangleShape2D_7nrdv")
+
+[node name="ColorRect" type="ColorRect" parent="right_dropzone5"]
+z_index = -1
+offset_left = -3.0
+offset_top = -7.0
+offset_right = 4.0
+offset_bottom = 7.0
+metadata/_edit_use_anchors_ = true
 
 [connection signal="body_entered" from="TileMap/GoalArea2D" to="fox" method="_on_goal_area_2d_body_entered"]
 [connection signal="body_entered" from="water/Area2D" to="fox" method="_on_area_2d_body_entered"]


### PR DESCRIPTION
## Motivation
closes #64

now Bridges can start at the Shore

## What was changed/added
added 5 drop zones to the Shore, the new drop zones are in the new Group right_dropzone which calculates the correct possition. 

## Testing

https://github.com/mango-gremlin/arch-enemies/assets/44133213/b8b99439-5188-40ca-ac79-e912aa10f87a