### PR TITLE
Squirrel now snaps to grid correctly

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -22,8 +22,8 @@ func is_correct_placement(body):
 			# if overlapping body is a forbidden one, it is never valid
 			if overlapping_body.is_in_group("forbidden"):
 				return false
-			# if overlapping body is dropable, check specifics for animals
-			elif overlapping_body.is_in_group("dropable"):
+			# if overlapping body is dropable and not its own, check specifics for animals
+			elif overlapping_body.is_in_group("dropable") and not body == overlapping_body.get_owner():
 				# get type of animal that overlapping drop zone belongs to
 				var overlapping_animal_type = Global.get_animal_type(overlapping_body.get_owner())
 				# if overlap zone belongs to a spider, it is always allowed
@@ -85,9 +85,6 @@ func _process(_delta):
 			# snaps the center of animal to the grid, which may become an issue for some sprite sizes
 			
 			tween.tween_property(self, "position", self.position, 0.2).set_ease(Tween.EASE_OUT)
-			print("is_inside_dropable: ", is_inside_dropable) 
-			print("is_inside_forbidden: " , is_inside_forbidden)
-			
 			# if placement is incorrect, snap back to original position
 			# otherwise animal remains in current position, snapped to grid
 			if not is_correct_placement(self):
@@ -120,17 +117,13 @@ func body_entered(body):
 	# and this body is in the group drobable
 	# set inside dropable to true so the process can register it as a dropable zone
 	# and change the colour of the body we just touched to signify we can drop it here
-	if body.is_in_group('dropable'):
-		print("entered dropable body")
+	if body.is_in_group('dropable') and not body == self:
 		is_inside_dropable = true
 		body.modulate = Color(Color.CORNFLOWER_BLUE, 1)
 		self.dropzone = body
 	# "not body self" prevents some unexpected results with overlapping collision zones
 	# of self, but may also be a problem in the future 
 	if body.is_in_group('forbidden') and not body == self:
-		print("entered forbidden body")
-		print(body.get_owner().name)
-		print(self.name)
 		is_inside_forbidden = true
 		
 
@@ -140,12 +133,10 @@ func _on_snake_body_exited(body):
 func body_exited(body):
 	# if the snake body stops touching a staticbody that has the dropable group
 	# set inside dropable to false & change the colour of that body back to original 
-	if body.is_in_group('dropable'):
-		print("exited dropable body")
+	if body.is_in_group('dropable') and not body == self:
 		is_inside_dropable = false
 		body.modulate = Color(Color.AQUAMARINE, 0.7)
 	if body.is_in_group('forbidden') and not body == self:
-		print("exited forbidden body")
 		is_inside_forbidden = false
 
 # JUST SQUIRREL THINGS

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -40,6 +40,7 @@ func is_correct_placement(body):
 					# only spiders can be dropped on another animal's bottom dropzone
 					elif overlapping_body.is_in_group("bottom_dropzone") and animal_type == "spider":
 						return true
+		return false
 	return false
 
 func _process(_delta):

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -14,31 +14,32 @@ var dropzone_occupied = false
 
 # checks if placement of animal relativ to other animal is correct
 func is_correct_placement(body):
-	var body_area2D = body.get_children()[2] # gets Area2D child, which can check for overlapping bodies
-	var animal_type = Global.get_animal_type(body)
-	# iterate through all overlapping bodies, and check if they are allowed or not
-	for overlapping_body in body_area2D.get_overlapping_bodies():
-		# if overlapping body is a forbidden one, it is never valid
-		if overlapping_body.is_in_group("forbidden"):
-			return false
-		# if overlapping body is dropable, check specifics for animals
-		elif overlapping_body.is_in_group("dropable"):
-			# get type of animal that overlapping drop zone belongs to
-			var overlapping_animal_type = Global.get_animal_type(overlapping_body.get_owner())
-			# if overlap zone belongs to a spider, it is always allowed
-			if overlapping_animal_type == "spider":
-				return true
-			# if not, normal rules apply
-			else:
-				# every animal can be dropped on another animal's top dropzone
-				if overlapping_body.is_in_group("top_dropzone"):
+	if is_inside_dropable:
+		var body_area2D = body.get_children()[2] # gets Area2D child, which can check for overlapping bodies
+		var animal_type = Global.get_animal_type(body)
+		# iterate through all overlapping bodies, and check if they are allowed or not
+		for overlapping_body in body_area2D.get_overlapping_bodies():
+			# if overlapping body is a forbidden one, it is never valid
+			if overlapping_body.is_in_group("forbidden"):
+				return false
+			# if overlapping body is dropable, check specifics for animals
+			elif overlapping_body.is_in_group("dropable"):
+				# get type of animal that overlapping drop zone belongs to
+				var overlapping_animal_type = Global.get_animal_type(overlapping_body.get_owner())
+				# if overlap zone belongs to a spider, it is always allowed
+				if overlapping_animal_type == "spider":
 					return true
-				# only squirrels and spiders can be dropped on another animal's side dropzones
-				elif overlapping_body.is_in_group("side_dropzone") and (animal_type == "squirrel" or animal_type == "spider"):
-					return true
-				# only spiders can be dropped on another animal's bottom dropzone
-				elif overlapping_body.is_in_group("bottom_dropzone") and animal_type == "spider":
-					return true
+				# if not, normal rules apply
+				else:
+					# every animal can be dropped on another animal's top dropzone
+					if overlapping_body.is_in_group("top_dropzone"):
+						return true
+					# only squirrels and spiders can be dropped on another animal's side dropzones
+					elif overlapping_body.is_in_group("side_dropzone") and (animal_type == "squirrel" or animal_type == "spider"):
+						return true
+					# only spiders can be dropped on another animal's bottom dropzone
+					elif overlapping_body.is_in_group("bottom_dropzone") and animal_type == "spider":
+						return true
 	return false
 
 func _process(_delta):

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/squirrel.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/squirrel.tscn
@@ -19,97 +19,90 @@ collision_mask = 3
 script = ExtResource("1_ss8yf")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-position = Vector2(0, 4)
+position = Vector2(0, 5)
 scale = Vector2(1, 1.8)
 texture = ExtResource("2_eib8h")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(0, 4)
+position = Vector2(0, 5)
 shape = SubResource("RectangleShape2D_m8jht")
 
 [node name="squirrel" type="Area2D" parent="."]
-position = Vector2(16, 9)
+position = Vector2(0, 5)
 collision_layer = 3
 collision_mask = 3
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="squirrel"]
-position = Vector2(-16, -5)
 shape = SubResource("RectangleShape2D_4bimj")
 
 [node name="left_dropzone" type="StaticBody2D" parent="." groups=["dropable", "side_dropzone"]]
-position = Vector2(-10, 0)
+position = Vector2(-10, 5)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone"]
-position = Vector2(0, 4)
 scale = Vector2(1, 2)
 shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="left_dropzone"]
 z_index = -1
 offset_left = -5.0
-offset_top = -6.0
+offset_top = -10.0
 offset_right = 5.0
-offset_bottom = 4.0
 scale = Vector2(1, 2)
 metadata/_edit_use_anchors_ = true
 
 [node name="right_dropzone" type="StaticBody2D" parent="." groups=["dropable", "side_dropzone"]]
-position = Vector2(10, 0)
+position = Vector2(10, 5)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone"]
-position = Vector2(0, 4)
 scale = Vector2(1, 2)
 shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="right_dropzone"]
 z_index = -1
 offset_left = -5.0
-offset_top = -6.0
+offset_top = -10.0
 offset_right = 5.0
-offset_bottom = 4.0
 scale = Vector2(1, 2)
 metadata/_edit_use_anchors_ = true
 
 [node name="top_dropzone" type="StaticBody2D" parent="." groups=["dropable", "top_dropzone"]]
-position = Vector2(0, -15)
+position = Vector2(0, -10)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
-position = Vector2(0, 4)
 shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="top_dropzone"]
 z_index = -1
 offset_left = -5.0
-offset_top = -1.0
+offset_top = -5.0
 offset_right = 5.0
-offset_bottom = 9.0
+offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
 
 [node name="bottom_dropzone" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
-position = Vector2(0, 15)
+position = Vector2(0, 20)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]
-position = Vector2(0, 4)
 shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="bottom_dropzone"]
 z_index = -1
 offset_left = -5.0
-offset_top = -1.0
+offset_top = -5.0
 offset_right = 5.0
-offset_bottom = 9.0
+offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
 
 [connection signal="body_entered" from="squirrel" to="." method="_on_squirrel_body_entered"]

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/squirrel.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/squirrel.tscn
@@ -19,17 +19,21 @@ collision_mask = 3
 script = ExtResource("1_ss8yf")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(0, 4)
 scale = Vector2(1, 1.8)
 texture = ExtResource("2_eib8h")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, 4)
 shape = SubResource("RectangleShape2D_m8jht")
 
 [node name="squirrel" type="Area2D" parent="."]
+position = Vector2(16, 9)
 collision_layer = 3
 collision_mask = 3
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="squirrel"]
+position = Vector2(-16, -5)
 shape = SubResource("RectangleShape2D_4bimj")
 
 [node name="left_dropzone" type="StaticBody2D" parent="." groups=["dropable", "side_dropzone"]]
@@ -39,14 +43,16 @@ collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone"]
+position = Vector2(0, 4)
 scale = Vector2(1, 2)
 shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="left_dropzone"]
 z_index = -1
 offset_left = -5.0
-offset_top = -10.0
+offset_top = -6.0
 offset_right = 5.0
+offset_bottom = 4.0
 scale = Vector2(1, 2)
 metadata/_edit_use_anchors_ = true
 
@@ -57,14 +63,16 @@ collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone"]
+position = Vector2(0, 4)
 scale = Vector2(1, 2)
 shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="right_dropzone"]
 z_index = -1
 offset_left = -5.0
-offset_top = -10.0
+offset_top = -6.0
 offset_right = 5.0
+offset_bottom = 4.0
 scale = Vector2(1, 2)
 metadata/_edit_use_anchors_ = true
 
@@ -75,14 +83,15 @@ collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
+position = Vector2(0, 4)
 shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="top_dropzone"]
 z_index = -1
 offset_left = -5.0
-offset_top = -5.0
+offset_top = -1.0
 offset_right = 5.0
-offset_bottom = 5.0
+offset_bottom = 9.0
 metadata/_edit_use_anchors_ = true
 
 [node name="bottom_dropzone" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
@@ -92,14 +101,15 @@ collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]
+position = Vector2(0, 4)
 shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="bottom_dropzone"]
 z_index = -1
 offset_left = -5.0
-offset_top = -5.0
+offset_top = -1.0
 offset_right = 5.0
-offset_bottom = 5.0
+offset_bottom = 9.0
 metadata/_edit_use_anchors_ = true
 
 [connection signal="body_entered" from="squirrel" to="." method="_on_squirrel_body_entered"]

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/squirrel.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/squirrel.tscn
@@ -33,42 +33,38 @@ collision_mask = 3
 shape = SubResource("RectangleShape2D_4bimj")
 
 [node name="left_dropzone" type="StaticBody2D" parent="." groups=["dropable", "side_dropzone"]]
-position = Vector2(-11, 6)
+position = Vector2(-11, 0)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone"]
-position = Vector2(0, -6)
 scale = Vector2(1, 2)
 shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="left_dropzone"]
 z_index = -1
 offset_left = -5.0
-offset_top = -16.0
+offset_top = -10.0
 offset_right = 5.0
-offset_bottom = -6.0
 scale = Vector2(1, 2)
 metadata/_edit_use_anchors_ = true
 
 [node name="right_dropzone" type="StaticBody2D" parent="." groups=["dropable", "side_dropzone"]]
-position = Vector2(11, -6)
+position = Vector2(11, 0)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone"]
-position = Vector2(0, 6)
 scale = Vector2(1, 2)
 shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="right_dropzone"]
 z_index = -1
 offset_left = -5.0
-offset_top = -4.0
+offset_top = -10.0
 offset_right = 5.0
-offset_bottom = 6.0
 scale = Vector2(1, 2)
 metadata/_edit_use_anchors_ = true
 

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
@@ -168,7 +168,7 @@ texture = ExtResource("7_lmu4n")
 script = ExtResource("8_puaob")
 
 [node name="squirrel" parent="." instance=ExtResource("7_1743r")]
-position = Vector2(160, 75)
+position = Vector2(160, 70)
 
 [connection signal="body_entered" from="TileMap/GoalArea2D" to="fox" method="_on_goal_area_2d_body_entered"]
 [connection signal="body_entered" from="water/Area2D" to="fox" method="_on_area_2d_body_entered"]

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
@@ -168,7 +168,7 @@ texture = ExtResource("7_lmu4n")
 script = ExtResource("8_puaob")
 
 [node name="squirrel" parent="." instance=ExtResource("7_1743r")]
-position = Vector2(160, 70)
+position = Vector2(160, 75)
 
 [connection signal="body_entered" from="TileMap/GoalArea2D" to="fox" method="_on_goal_area_2d_body_entered"]
 [connection signal="body_entered" from="water/Area2D" to="fox" method="_on_area_2d_body_entered"]


### PR DESCRIPTION
## Motivation
closes #77 

## What was changed/added
Squirrel was moved 5 pixel downwards, hitboxes have been adjusted accordingly. This fixed the grid-snapping, but allowed placement of the squirrel wherever you wanted, because it detected its own hitboxes as valid dropzones. To fix this, we changed the ``is_correct_placement`` function so that it ignores its own valid dropzones.

## Testing
As you can see, the squirrel snaps to grid, and correctly snaps back if placed in a forbidden spot.
https://github.com/mango-gremlin/arch-enemies/assets/104799849/cfd5d6d5-f491-4797-a62f-26441c1ee590