### PR TITLE
Made snapping continous

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -57,19 +57,18 @@ func _process(_delta):
 			
 		if Input.is_action_pressed("click"):
 			# during the time mouse click is held down,
-			# object continues following mouse
-			self.global_position = get_global_mouse_position() - mouse_offset
+			# object continues following mouse position, rounded to grid size.
+			var target_position_x = Global.round_to_nearest(get_global_mouse_position().x - mouse_offset.x, grid_size)
+			var target_position_y = Global.round_to_nearest(get_global_mouse_position().y - mouse_offset.y, grid_size)
+			self.global_position.x = target_position_x
+			self.global_position.y = target_position_y
 			
 		elif Input.is_action_just_released("click"):
 			# when click is released:
 			
 			# dropped object should not be on top level anymore
 			self.top_level = false
-			
-			# snap to nearest position in grid
-			self.position.x = Global.round_to_nearest(self.position.x, grid_size)
-			self.position.y = Global.round_to_nearest(self.position.y, grid_size)
-		
+
 			# 1. nothing is being currently dragged
 			self.is_dragging = false
 			Global.something_is_being_dragged = false


### PR DESCRIPTION
## Motivation
closes #96

By having the animal snap to the grid during the dragging the player can see where it will end up after letting go of it and we prevent the animal exiting a valid drop zone due to snapping. 

## What was changed/added

I changed the dragging script.
Now the position of the mouse gets rounded to the grid size while accounting for offset and saved as 2 new variables, target_position_x and target_position_y. 
The animal is then moved to those coordinates.

## Testing

Here you can see the changes in action:

https://github.com/mango-gremlin/arch-enemies/assets/116198748/2d5d2ef9-8968-4e87-a27f-c5122cbbaf68

## Additional Information

These changes might invalidate Pull Requests #86 and #94 depending on how the implementation.

