### PR TITLE
Issue64/drop zones on shores 3

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -24,22 +24,25 @@ func is_correct_placement(body):
 		# if overlapping body is dropable, check specifics for animals
 		elif overlapping_body.is_in_group("dropable"):
 			# get type of animal that overlapping drop zone belongs to
+			print("1: ") 
 			if not overlapping_body.is_in_group("shore_dropzone"):  #the shore has no animal_type therefore this check has to be skipped 
+				print("2: ") 
 				var overlapping_animal_type = Global.get_animal_type(overlapping_body.get_owner())
 				# if overlap zone belongs to a spider, it is always allowed
 				if overlapping_animal_type == "spider":
 					return true
 			# if not, normal rules apply
-			else:
-				# every animal can be dropped on another animal's top dropzone
-				if overlapping_body.is_in_group("top_dropzone"):
-					return true
-				# only squirrels and spiders can be dropped on another animal's side dropzones
-				elif overlapping_body.is_in_group("side_dropzone") and (animal_type == "squirrel" or animal_type == "spider"):
-					return true
-				# only spiders can be dropped on another animal's bottom dropzone
-				elif overlapping_body.is_in_group("bottom_dropzone") and animal_type == "spider":
-					return true
+			
+			print("3: ") 
+			# every animal can be dropped on another animal's top dropzone
+			if overlapping_body.is_in_group("top_dropzone"):
+				return true
+			# only squirrels and spiders can be dropped on another animal's side dropzones
+			elif overlapping_body.is_in_group("side_dropzone") and (animal_type == "squirrel" or animal_type == "spider"):
+				return true
+			# only spiders can be dropped on another animal's bottom dropzone
+			elif overlapping_body.is_in_group("bottom_dropzone") and animal_type == "spider":
+				return true
 	return false
 
 func _process(_delta):

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -24,16 +24,12 @@ func is_correct_placement(body):
 		# if overlapping body is dropable, check specifics for animals
 		elif overlapping_body.is_in_group("dropable"):
 			# get type of animal that overlapping drop zone belongs to
-			print("1: ") 
 			if not overlapping_body.is_in_group("shore_dropzone"):  #the shore has no animal_type therefore this check has to be skipped 
-				print("2: ") 
 				var overlapping_animal_type = Global.get_animal_type(overlapping_body.get_owner())
 				# if overlap zone belongs to a spider, it is always allowed
 				if overlapping_animal_type == "spider":
 					return true
-			# if not, normal rules apply
-			
-			print("3: ") 
+					
 			# every animal can be dropped on another animal's top dropzone
 			if overlapping_body.is_in_group("top_dropzone"):
 				return true

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
@@ -48,6 +48,7 @@ texture = ExtResource("2_640fj")
 1:1/0/physics_layer_0/angular_velocity = 0.0
 
 [sub_resource type="TileSet" id="TileSet_rwph5"]
+tile_size = Vector2i(10, 10)
 physics_layer_0/collision_layer = 1
 terrain_set_0/mode = 0
 sources/0 = SubResource("TileSetAtlasSource_s2tkw")

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
@@ -196,7 +196,7 @@ scale = Vector2(8, 1)
 color = Color(1, 100, 1, 1)
 metadata/_edit_use_anchors_ = true
 
-[node name="shore_right_dropzone2" type="StaticBody2D" parent="." groups=["dropable", "right_dropzone", "shore_dropzone"]]
+[node name="shore_right_dropzone2" type="StaticBody2D" parent="." groups=["dropable", "right_dropzone", "shore_dropzone", "side_dropzone"]]
 position = Vector2(112, 143)
 collision_layer = 2
 collision_mask = 2

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
@@ -168,7 +168,7 @@ script = SubResource("GDScript_62t5p")
 
 [node name="Grid10x10" type="Sprite2D" parent="."]
 z_index = 1
-position = Vector2(241, 219)
+position = Vector2(205, 205)
 texture = ExtResource("7_lmu4n")
 script = ExtResource("8_puaob")
 

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
@@ -168,7 +168,7 @@ script = SubResource("GDScript_62t5p")
 
 [node name="Grid10x10" type="Sprite2D" parent="."]
 z_index = 1
-position = Vector2(205, 205)
+position = Vector2(241, 219)
 texture = ExtResource("7_lmu4n")
 script = ExtResource("8_puaob")
 


### PR DESCRIPTION
## Motivation
closes #64

## What was changed/added
added drop zones to the Shore with new Group "shore_dropzone"

now the animal drop zones work again, one check was indented wrongly 

## Testing


https://github.com/mango-gremlin/arch-enemies/assets/44133213/ceb80974-d234-4133-9024-674f01d44973

