### PR TITLE
Added a button that spawns spiders.

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/SpiderSpawningButton.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/SpiderSpawningButton.gd
@@ -1,0 +1,19 @@
+extends Button
+
+# The scene spawned by the button. Snek in this case
+var new_animal = preload("res://spider.tscn")
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+# creates a new instance of the snek class and adds it to the world.
+func _on_pressed():
+	var new_spider = new_animal.instantiate()
+	new_spider.position = Vector2(100,100)
+	self.get_parent().add_child(new_spider)

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/world.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=3 uid="uid://cf5udd6l65fuv"]
+[gd_scene load_steps=26 format=3 uid="uid://cf5udd6l65fuv"]
 
 [ext_resource type="Texture2D" uid="uid://d4khq8o7aaei" path="res://assets/green.png" id="1_m0btg"]
 [ext_resource type="Texture2D" uid="uid://dc2lxeyr45vp3" path="res://assets/blue_dark.png" id="2_640fj"]
@@ -14,6 +14,7 @@
 [ext_resource type="Script" path="res://gridVisibility.gd" id="8_puaob"]
 [ext_resource type="Script" path="res://SnakeSpawningButton.gd" id="11_g8gs2"]
 [ext_resource type="Script" path="res://SquirrelSpawningButton.gd" id="12_mkafk"]
+[ext_resource type="Script" path="res://SpiderSpawningButton.gd" id="15_dx35d"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_s2tkw"]
 texture = ExtResource("1_m0btg")
@@ -179,25 +180,13 @@ position = Vector2(140, 150)
 [node name="snek2" parent="." instance=ExtResource("3_0bug4")]
 position = Vector2(300, 130)
 
-[node name="DragModeButton" type="CheckButton" parent="."]
-offset_left = 208.0
-offset_top = 4.0
-offset_right = 340.0
-offset_bottom = 35.0
-text = "drag mode"
-alignment = 1
-icon_alignment = 1
-script = ExtResource("6_8qx0u")
-
 [node name="DeathHazard" parent="." instance=ExtResource("6_l6n76")]
 
-[node name="GoalMenu" parent="." instance=ExtResource("6_xdjb3")]
-visible = false
-top_level = true
-anchors_preset = -1
-offset_right = 3.0
-offset_bottom = -1.0
-script = SubResource("GDScript_62t5p")
+[node name="Grid2" type="Sprite2D" parent="."]
+z_index = 1
+position = Vector2(705, 205)
+texture = ExtResource("7_lmu4n")
+script = ExtResource("8_puaob")
 
 [node name="Grid1" type="Sprite2D" parent="."]
 z_index = 1
@@ -208,31 +197,55 @@ script = ExtResource("8_puaob")
 [node name="squirrel" parent="." instance=ExtResource("7_1743r")]
 position = Vector2(160, 70)
 
+[node name="DragModeButton" type="CheckButton" parent="."]
+offset_left = 208.0
+offset_top = 4.0
+offset_right = 340.0
+offset_bottom = 35.0
+text = "drag mode"
+alignment = 1
+icon_alignment = 1
+script = ExtResource("6_8qx0u")
+
+[node name="GoalMenu" parent="." instance=ExtResource("6_xdjb3")]
+visible = false
+top_level = true
+anchors_preset = -1
+offset_right = 3.0
+offset_bottom = -1.0
+script = SubResource("GDScript_62t5p")
+
 [node name="SnakeButton" type="Button" parent="."]
-offset_left = 24.0
-offset_top = 178.0
-offset_right = 79.0
-offset_bottom = 209.0
+offset_left = 75.0
+offset_top = 265.0
+offset_right = 130.0
+offset_bottom = 296.0
+scale = Vector2(0.5, 0.5)
 text = "Snake"
 script = ExtResource("11_g8gs2")
 
-[node name="Button" type="Button" parent="."]
-offset_left = 18.0
-offset_top = 214.0
-offset_right = 87.0
-offset_bottom = 245.0
+[node name="SquirrelButton" type="Button" parent="."]
+offset_left = 108.0
+offset_top = 266.0
+offset_right = 177.0
+offset_bottom = 297.0
+scale = Vector2(0.5, 0.5)
 text = "Squirrel"
 script = ExtResource("12_mkafk")
 
-[node name="Grid2" type="Sprite2D" parent="."]
-z_index = 1
-position = Vector2(705, 205)
-texture = ExtResource("7_lmu4n")
-script = ExtResource("8_puaob")
+[node name="SpiderButton" type="Button" parent="."]
+offset_left = 148.0
+offset_top = 266.0
+offset_right = 206.0
+offset_bottom = 297.0
+scale = Vector2(0.5, 0.5)
+text = "Spider"
+script = ExtResource("15_dx35d")
 
 [connection signal="body_entered" from="TileMap/GoalArea2D" to="fox" method="_on_goal_area_2d_body_entered"]
 [connection signal="body_entered" from="water/Area2D" to="fox" method="_on_area_2d_body_entered"]
-[connection signal="toggled" from="DragModeButton" to="DragModeButton" method="_on_toggled"]
 [connection signal="body_entered" from="DeathHazard" to="fox" method="_on_death_hazard_body_entered"]
+[connection signal="toggled" from="DragModeButton" to="DragModeButton" method="_on_toggled"]
 [connection signal="pressed" from="SnakeButton" to="SnakeButton" method="_on_pressed"]
-[connection signal="pressed" from="Button" to="Button" method="_on_pressed"]
+[connection signal="pressed" from="SquirrelButton" to="SquirrelButton" method="_on_pressed"]
+[connection signal="pressed" from="SpiderButton" to="SpiderButton" method="_on_pressed"]


### PR DESCRIPTION
## Motivation
closes #102 

We added spiders to the game, so we need a button to spawn them so they can be used to build the bridge.

## What was changed/added

I added a button that is connected to a script that instantiates a spider when the button is pressed.
I also changed the size and position of the button, because we want to make the level smaller and sorted all of the control element nodes to be next to each other in the scene tree.

## Testing

Conjuring a spider:

https://github.com/mango-gremlin/arch-enemies/assets/116198748/6df52cf2-a9ac-46eb-8003-2818861bfb02


