### PR TITLE
adjusted snake hitboxes to fit grid

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/snek.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/snek.tscn
@@ -5,19 +5,19 @@
 [ext_resource type="Script" path="res://allowed_snake_area.gd" id="3_fqrgl"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_43xhd"]
-size = Vector2(50, 10)
+size = Vector2(48, 10)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_i2o3k"]
 size = Vector2(48, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_lyvfn"]
-size = Vector2(8, 8)
+size = Vector2(9, 10)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_f3mbg"]
-size = Vector2(38, 8)
+size = Vector2(40, 9)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_f6euc"]
-size = Vector2(38, 8)
+size = Vector2(39, 9)
 
 [node name="snakeBod" type="StaticBody2D" groups=["draggable", "snake"]]
 collision_layer = 3
@@ -25,7 +25,7 @@ collision_mask = 3
 script = ExtResource("1_gtwqh")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-scale = Vector2(0.85, 0.95)
+scale = Vector2(0.87, 0.925)
 texture = ExtResource("1_c08hy")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -38,14 +38,34 @@ collision_mask = 3
 [node name="CollisionShape2D" type="CollisionShape2D" parent="snake"]
 shape = SubResource("RectangleShape2D_i2o3k")
 
+[node name="forbidden_dropzone" type="StaticBody2D" parent="." groups=["bottom_dropzone", "forbidden"]]
+position = Vector2(-23, 11)
+collision_layer = 2
+collision_mask = 2
+script = ExtResource("3_fqrgl")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="forbidden_dropzone"]
+position = Vector2(-1, 0)
+polygon = PackedVector2Array(40, -26, 40, -17, 49, -17, 49, -5, 40, -5, 40, 4, 59, 4, 59, -26)
+
+[node name="ColorRect" type="ColorRect" parent="forbidden_dropzone"]
+z_index = -1
+offset_left = 38.0
+offset_top = -26.0
+offset_right = 48.0
+offset_bottom = -16.0
+scale = Vector2(2, 3)
+color = Color(1, 0, 0, 1)
+metadata/_edit_use_anchors_ = true
+
 [node name="left_dropzone" type="StaticBody2D" parent="." groups=["dropable", "side_dropzone"]]
-position = Vector2(-34, 0)
+position = Vector2(-35, 0)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone"]
-position = Vector2(5, 0)
+position = Vector2(4.5, 0)
 shape = SubResource("RectangleShape2D_lyvfn")
 
 [node name="ColorRect" type="ColorRect" parent="left_dropzone"]
@@ -56,13 +76,13 @@ offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
 
 [node name="top_dropzone" type="StaticBody2D" parent="." groups=["dropable", "top_dropzone"]]
-position = Vector2(-23, -11)
+position = Vector2(-24, -11)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
-position = Vector2(19, 1)
+position = Vector2(19, 0.5)
 shape = SubResource("RectangleShape2D_f3mbg")
 
 [node name="ColorRect" type="ColorRect" parent="top_dropzone"]
@@ -76,13 +96,13 @@ color = Color(1, 100, 1, 1)
 metadata/_edit_use_anchors_ = true
 
 [node name="bottom_dropzone" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
-position = Vector2(-23, 11)
+position = Vector2(-24, 11)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]
-position = Vector2(19, -1)
+position = Vector2(18.5, -0.5)
 shape = SubResource("RectangleShape2D_f6euc")
 
 [node name="ColorRect" type="ColorRect" parent="bottom_dropzone"]
@@ -93,25 +113,6 @@ offset_right = 9.0
 offset_bottom = 4.0
 scale = Vector2(4, 1)
 metadata/_edit_use_anchors_ = true
-
-[node name="forbidden_dropzone" type="StaticBody2D" parent="." groups=["bottom_dropzone", "forbidden"]]
-position = Vector2(-23, 11)
-collision_layer = 2
-collision_mask = 2
-script = ExtResource("3_fqrgl")
-
-[node name="ColorRect" type="ColorRect" parent="forbidden_dropzone"]
-z_index = -1
-offset_left = 40.0
-offset_top = -26.0
-offset_right = 50.0
-offset_bottom = -16.0
-scale = Vector2(2, 3)
-color = Color(1, 0, 0, 1)
-metadata/_edit_use_anchors_ = true
-
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="forbidden_dropzone"]
-polygon = PackedVector2Array(40, -26, 40, -17, 49, -17, 49, -5, 40, -5, 40, 4, 56, 4, 56, -26)
 
 [connection signal="body_entered" from="snake" to="." method="_on_snake_body_entered"]
 [connection signal="body_exited" from="snake" to="." method="_on_snake_body_exited"]


### PR DESCRIPTION

## Motivation
closes #104 

## What was changed/added
Slightly adjusted snake hitboxes so they (visually) fit the grid. Took most of the work from #86, adjusted it only slighty 

## Testing
As seen below, the snake and its hitboxes fits the grid 
https://github.com/mango-gremlin/arch-enemies/assets/104799849/2a0208a8-58cd-4027-928b-bbb3626108b6


## Additional Information
As you can see below, the hitboxes still don't look pretty internall, especially considering the centering of the collision zones. After the prototypes have been merged together, we might want to fix that. 
![image](https://github.com/mango-gremlin/arch-enemies/assets/104799849/40cdb36e-f2ba-4d35-9263-5b46a6932d4d)
Also, the red rectangle is now brown thanks to the background, it doesn't look good.

