### PR TITLE
adjust hitboxes of the squirrel and mr spider

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/spider.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/spider.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://bqtg1c4s2pkab"]
+[gd_scene load_steps=10 format=3 uid="uid://bqtg1c4s2pkab"]
 
 [ext_resource type="Script" path="res://DragObject.gd" id="1_fk6ir"]
 [ext_resource type="Texture2D" uid="uid://cagtqr073bxj2" path="res://assets/spider.png" id="2_87e2g"]
@@ -11,7 +11,16 @@ size = Vector2(10, 10)
 size = Vector2(10, 10)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_2xjkc"]
-size = Vector2(10, 10)
+size = Vector2(9, 10)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_v5quv"]
+size = Vector2(10, 9)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_mvc5n"]
+size = Vector2(9, 10)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_cfceg"]
+size = Vector2(10, 9)
 
 [node name="spiderBod" type="StaticBody2D" groups=["draggable", "spider"]]
 collision_layer = 3
@@ -39,6 +48,7 @@ collision_mask = 2
 script = ExtResource("3_i8vs8")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone"]
+position = Vector2(-0.5, 0)
 shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="left_dropzone"]
@@ -55,9 +65,6 @@ collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_i8vs8")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone"]
-shape = SubResource("RectangleShape2D_2xjkc")
-
 [node name="ColorRect" type="ColorRect" parent="right_dropzone"]
 z_index = -1
 offset_left = -5.0
@@ -66,14 +73,15 @@ offset_right = 5.0
 offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
 
+[node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone"]
+position = Vector2(-10, -10.5)
+shape = SubResource("RectangleShape2D_v5quv")
+
 [node name="top_dropzone" type="StaticBody2D" parent="." groups=["dropable", "top_dropzone"]]
 position = Vector2(0, -10)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_i8vs8")
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
-shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="top_dropzone"]
 z_index = -1
@@ -83,14 +91,15 @@ offset_right = 5.0
 offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
 
+[node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
+position = Vector2(10.5, 10)
+shape = SubResource("RectangleShape2D_mvc5n")
+
 [node name="bottom_dropzone" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
 position = Vector2(0, 10)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_i8vs8")
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]
-shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="bottom_dropzone"]
 z_index = -1
@@ -99,6 +108,10 @@ offset_top = -5.0
 offset_right = 5.0
 offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]
+position = Vector2(0, 0.5)
+shape = SubResource("RectangleShape2D_cfceg")
 
 [connection signal="body_entered" from="squirrel" to="." method="_on_squirrel_body_entered" flags=18]
 [connection signal="body_exited" from="squirrel" to="." method="_on_squirrel_body_exited" flags=18]

--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/squirrel.tscn
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/squirrel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://dipauq7hxbt1f"]
+[gd_scene load_steps=10 format=3 uid="uid://dipauq7hxbt1f"]
 
 [ext_resource type="Script" path="res://DragObject.gd" id="1_ss8yf"]
 [ext_resource type="Texture2D" uid="uid://smnm35pbv18o" path="res://assets/box_squirrel.png" id="2_eib8h"]
@@ -11,7 +11,16 @@ size = Vector2(10, 20)
 size = Vector2(10, 20)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_2xjkc"]
-size = Vector2(10, 10)
+size = Vector2(9, 10)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_ar825"]
+size = Vector2(10, 9)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_r1da8"]
+size = Vector2(9, 20)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_abhdq"]
+size = Vector2(10, 9)
 
 [node name="squirrelBod" type="StaticBody2D" groups=["draggable", "squirrel"]]
 collision_layer = 3
@@ -42,6 +51,7 @@ collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone"]
+position = Vector2(-0.5, 0)
 scale = Vector2(1, 2)
 shape = SubResource("RectangleShape2D_2xjkc")
 
@@ -59,10 +69,6 @@ collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_l28rr")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone"]
-scale = Vector2(1, 2)
-shape = SubResource("RectangleShape2D_2xjkc")
-
 [node name="ColorRect" type="ColorRect" parent="right_dropzone"]
 z_index = -1
 offset_left = -5.0
@@ -71,14 +77,15 @@ offset_right = 5.0
 scale = Vector2(1, 2)
 metadata/_edit_use_anchors_ = true
 
+[node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone"]
+position = Vector2(-10, -15.5)
+shape = SubResource("RectangleShape2D_ar825")
+
 [node name="top_dropzone" type="StaticBody2D" parent="." groups=["dropable", "top_dropzone"]]
 position = Vector2(0, -10)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_l28rr")
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
-shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="top_dropzone"]
 z_index = -1
@@ -88,14 +95,15 @@ offset_right = 5.0
 offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
 
+[node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
+position = Vector2(10.5, 15)
+shape = SubResource("RectangleShape2D_r1da8")
+
 [node name="bottom_dropzone" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
 position = Vector2(0, 20)
 collision_layer = 2
 collision_mask = 2
 script = ExtResource("3_l28rr")
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]
-shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="bottom_dropzone"]
 z_index = -1
@@ -104,6 +112,10 @@ offset_top = -5.0
 offset_right = 5.0
 offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]
+position = Vector2(0, 0.5)
+shape = SubResource("RectangleShape2D_abhdq")
 
 [connection signal="body_entered" from="squirrel" to="." method="_on_squirrel_body_entered"]
 [connection signal="body_exited" from="squirrel" to="." method="_on_squirrel_body_exited"]


### PR DESCRIPTION
## Motivation
closes #111

Before, the CollisionShape2D of the animal dropozones were touching each other, which (for some reason) is counted the same as overlapping. This resulted in weird color changes.

## What was changed/added
The hitboxes were resized

## Testing
![image](https://github.com/mango-gremlin/arch-enemies/assets/57258671/b209052a-20ae-48ce-b3ae-dd98bf313730)
![image](https://github.com/mango-gremlin/arch-enemies/assets/57258671/86252bfe-7f2e-4715-b384-0afc06d5070c)
