### PR TITLE
fix spider adjacent placement

### DIFF
--- a/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
+++ b/testing_area/prototype_testing/MarcelRaffaelKatjaGlenn_BridgeNoGridPrototype1/Prototype_Bridges_1.3/DragObject.gd
@@ -14,7 +14,7 @@ var dropzone_occupied = false
 
 # checks if placement of animal relativ to other animal is correct
 func is_correct_placement(body):
-	if is_inside_dropable:
+	if is_inside_dropable and not is_inside_forbidden:
 		var body_area2D = body.get_children()[2] # gets Area2D child, which can check for overlapping bodies
 		var animal_type = Global.get_animal_type(body)
 		# iterate through all overlapping bodies, and check if they are allowed or not


### PR DESCRIPTION
## Motivation
closes #112 

## What was changed/added
added one line of code that checks if animal was in forbidden zone before considering animal-specific/shore-specific placement

## Testing
[Screencast from 04.12.2023 13:59:01.webm](https://github.com/mango-gremlin/arch-enemies/assets/104799849/8032d3cb-fcc5-4c01-8632-ec0a95283ef0)


## Additional Information
Found another bug: if you drag an animal through two overlapping forbidden zones, then ``is_inside_forbidden`` is always ``true``.  Should be fixed in #87, as overlapping forbidden zones should not longer be possible in general (maybe except hazards?)
