### PR TITLE
Fixed wrong dropzones lighting up

### DIFF
--- a/Arch-enemies/bridges/scenes/animals/snake.tscn
+++ b/Arch-enemies/bridges/scenes/animals/snake.tscn
@@ -11,13 +11,13 @@ size = Vector2(48, 10)
 size = Vector2(48, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_lyvfn"]
-size = Vector2(9, 10)
+size = Vector2(8, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_f3mbg"]
-size = Vector2(40, 9)
+size = Vector2(38, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_f6euc"]
-size = Vector2(39, 9)
+size = Vector2(38, 8)
 
 [node name="snakeBod" type="StaticBody2D" node_paths=PackedStringArray("body_area2D") groups=["draggable", "snake"]]
 collision_layer = 3
@@ -66,7 +66,7 @@ collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone"]
-position = Vector2(4.5, 0)
+position = Vector2(5, 0)
 shape = SubResource("RectangleShape2D_lyvfn")
 
 [node name="ColorRect" type="ColorRect" parent="left_dropzone"]
@@ -83,7 +83,7 @@ collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
-position = Vector2(19, 0.5)
+position = Vector2(19, 1)
 shape = SubResource("RectangleShape2D_f3mbg")
 
 [node name="ColorRect" type="ColorRect" parent="top_dropzone"]
@@ -103,7 +103,7 @@ collision_mask = 2
 script = ExtResource("3_fqrgl")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]
-position = Vector2(18.5, -0.5)
+position = Vector2(19, -1)
 shape = SubResource("RectangleShape2D_f6euc")
 
 [node name="ColorRect" type="ColorRect" parent="bottom_dropzone"]

--- a/Arch-enemies/bridges/scenes/animals/spider.tscn
+++ b/Arch-enemies/bridges/scenes/animals/spider.tscn
@@ -11,16 +11,16 @@ size = Vector2(10, 10)
 size = Vector2(10, 10)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_2xjkc"]
-size = Vector2(9, 10)
+size = Vector2(8, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_v5quv"]
-size = Vector2(10, 9)
+size = Vector2(8, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_mvc5n"]
-size = Vector2(9, 10)
+size = Vector2(8, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_cfceg"]
-size = Vector2(10, 9)
+size = Vector2(8, 8)
 
 [node name="spiderBod" type="StaticBody2D" node_paths=PackedStringArray("body_area2D") groups=["draggable", "spider"]]
 collision_layer = 3
@@ -49,7 +49,6 @@ collision_mask = 2
 script = ExtResource("3_i8vs8")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone"]
-position = Vector2(-0.5, 0)
 shape = SubResource("RectangleShape2D_2xjkc")
 
 [node name="ColorRect" type="ColorRect" parent="left_dropzone"]
@@ -75,7 +74,6 @@ offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone"]
-position = Vector2(-10, -10.5)
 shape = SubResource("RectangleShape2D_v5quv")
 
 [node name="top_dropzone" type="StaticBody2D" parent="." groups=["dropable", "top_dropzone"]]
@@ -93,7 +91,6 @@ offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
-position = Vector2(10.5, 10)
 shape = SubResource("RectangleShape2D_mvc5n")
 
 [node name="bottom_dropzone" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
@@ -111,7 +108,6 @@ offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]
-position = Vector2(0, 0.5)
 shape = SubResource("RectangleShape2D_cfceg")
 
 [connection signal="body_entered" from="spider" to="." method="_on_spider_body_entered"]

--- a/Arch-enemies/bridges/scenes/animals/squirrel.tscn
+++ b/Arch-enemies/bridges/scenes/animals/squirrel.tscn
@@ -11,16 +11,16 @@ size = Vector2(10, 20)
 size = Vector2(10, 20)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_2xjkc"]
-size = Vector2(9, 10)
+size = Vector2(8, 9)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ar825"]
-size = Vector2(10, 9)
+size = Vector2(8, 18)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_r1da8"]
-size = Vector2(9, 20)
+size = Vector2(8, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_abhdq"]
-size = Vector2(10, 9)
+size = Vector2(8, 8)
 
 [node name="squirrelBod" type="StaticBody2D" node_paths=PackedStringArray("body_area2D") groups=["draggable", "squirrel"]]
 collision_layer = 3
@@ -52,7 +52,6 @@ collision_mask = 2
 script = ExtResource("3_l28rr")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="left_dropzone"]
-position = Vector2(-0.5, 0)
 scale = Vector2(1, 2)
 shape = SubResource("RectangleShape2D_2xjkc")
 
@@ -79,7 +78,6 @@ scale = Vector2(1, 2)
 metadata/_edit_use_anchors_ = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="right_dropzone"]
-position = Vector2(-10, -15.5)
 shape = SubResource("RectangleShape2D_ar825")
 
 [node name="top_dropzone" type="StaticBody2D" parent="." groups=["dropable", "top_dropzone"]]
@@ -97,7 +95,6 @@ offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="top_dropzone"]
-position = Vector2(10.5, 15)
 shape = SubResource("RectangleShape2D_r1da8")
 
 [node name="bottom_dropzone" type="StaticBody2D" parent="." groups=["bottom_dropzone", "dropable"]]
@@ -115,7 +112,6 @@ offset_bottom = 5.0
 metadata/_edit_use_anchors_ = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="bottom_dropzone"]
-position = Vector2(0, 0.5)
 shape = SubResource("RectangleShape2D_abhdq")
 
 [connection signal="body_entered" from="squirrel" to="." method="_on_squirrel_body_entered"]

--- a/Arch-enemies/bridges/scenes/bridge_1.tscn
+++ b/Arch-enemies/bridges/scenes/bridge_1.tscn
@@ -129,10 +129,10 @@ sources/0 = SubResource("TileSetAtlasSource_vsiy0")
 size = Vector2(243.5, 54)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_0tifu"]
-size = Vector2(8, 9.5)
+size = Vector2(8, 4.48757)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_63llj"]
-size = Vector2(78, 8)
+size = Vector2(28, 7.99175)
 
 [sub_resource type="GDScript" id="GDScript_62t5p"]
 script/source = "extends Control
@@ -256,8 +256,7 @@ collision_mask = 2
 script = ExtResource("13_qdl2b")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="shore_right_dropzone"]
-position = Vector2(5, -2.4931)
-scale = Vector2(1, 0.5)
+position = Vector2(5, -2.5)
 shape = SubResource("RectangleShape2D_0tifu")
 
 [node name="ColorRect" type="ColorRect" parent="shore_right_dropzone"]
@@ -276,16 +275,14 @@ script = ExtResource("13_qdl2b")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="shore_top_dropzone"]
 position = Vector2(-1, 1)
-scale = Vector2(0.375, 1)
 shape = SubResource("RectangleShape2D_63llj")
 
 [node name="ColorRect" type="ColorRect" parent="shore_top_dropzone"]
 z_index = -1
 offset_left = -16.0
-offset_top = -3.98896
-offset_right = -6.0
-offset_bottom = 6.01104
-scale = Vector2(3, 1)
+offset_top = -4.0
+offset_right = 14.0
+offset_bottom = 6.0
 color = Color(1, 100, 1, 1)
 metadata/_edit_use_anchors_ = true
 


### PR DESCRIPTION
## Motivation
closes #129

When attaching animals to each other the correct zones should light up.

## What was changed/added

On the squirrel and spider the collision zones of the top and right dropzone where switched, so I switched them to their correct position. Additionally collision zones register overlap even if they only occupy adjacent pixels and their edges touch, so I reduced the size of the collision zones by 1 around the edges. This should not lead to any problems since animals only move in increments of 10

## Testing


https://github.com/mango-gremlin/arch-enemies/assets/116198748/1b95f440-119b-4611-adb7-462d77e2986e

