### PR TITLE
Fixed snapping bugs

### DIFF
--- a/Arch-enemies/bridges/scenes/animals/snake.tscn
+++ b/Arch-enemies/bridges/scenes/animals/snake.tscn
@@ -50,7 +50,7 @@ script = ExtResource("3_fqrgl")
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="forbidden_Area2D/forbidden_dropzone"]
 position = Vector2(-50, 11)
-polygon = PackedVector2Array(40, -26, 40, -17, 50, -17, 50, -5, 40, -5, 40, 4, 59, 4, 59, -26)
+polygon = PackedVector2Array(40, -25, 40, -17, 50, -17, 50, -5, 40, -5, 40, 3, 58, 3, 58, -25)
 
 [node name="ColorRect" type="ColorRect" parent="forbidden_Area2D/forbidden_dropzone"]
 z_index = -1

--- a/Arch-enemies/bridges/scenes/animals/snake.tscn
+++ b/Arch-enemies/bridges/scenes/animals/snake.tscn
@@ -6,10 +6,10 @@
 [ext_resource type="Script" path="res://bridges/scenes/animals/forbidden_visibility.gd" id="3_i22jp"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_43xhd"]
-size = Vector2(50, 10)
+size = Vector2(48, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_i2o3k"]
-size = Vector2(50, 8)
+size = Vector2(48, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_lyvfn"]
 size = Vector2(8, 8)
@@ -64,7 +64,7 @@ metadata/_edit_use_anchors_ = true
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="forbidden_Area2D"]
 position = Vector2(-50, 11)
-polygon = PackedVector2Array(40, -26, 40, -17, 50, -17, 50, -5, 40, -5, 40, 4, 59, 4, 59, -26)
+polygon = PackedVector2Array(40, -25, 40, -24.9855, 40, -17, 50, -17, 50, -5, 40, -5, 40, 3, 58, 3, 58, -25)
 
 [node name="ColorRect" type="ColorRect" parent="forbidden_Area2D"]
 z_index = -1

--- a/Arch-enemies/bridges/scenes/animals/spider.tscn
+++ b/Arch-enemies/bridges/scenes/animals/spider.tscn
@@ -5,10 +5,10 @@
 [ext_resource type="Script" path="res://bridges/script/dropzones_visibility.gd" id="3_i8vs8"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_m8jht"]
-size = Vector2(10, 10)
+size = Vector2(8, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_4bimj"]
-size = Vector2(10, 10)
+size = Vector2(8, 8)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_2xjkc"]
 size = Vector2(8, 8)

--- a/Arch-enemies/bridges/scenes/animals/squirrel.tscn
+++ b/Arch-enemies/bridges/scenes/animals/squirrel.tscn
@@ -5,10 +5,10 @@
 [ext_resource type="Script" path="res://bridges/script/dropzones_visibility.gd" id="3_l28rr"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_m8jht"]
-size = Vector2(10, 20)
+size = Vector2(8, 18)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_4bimj"]
-size = Vector2(10, 20)
+size = Vector2(8, 18)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_2xjkc"]
 size = Vector2(8, 9)

--- a/Arch-enemies/bridges/script/drag_handler.gd
+++ b/Arch-enemies/bridges/script/drag_handler.gd
@@ -4,7 +4,6 @@ const STANDARD_COLOR = Color(Color.AQUAMARINE, 0.7)
 const TRIGGERED_COLOR = Color(Color.CORNFLOWER_BLUE, 1)
 
 var draggable := false
-var is_inside_dropable := false
 var is_inside_forbidden := false
 var mouse_offset : Vector2
 var initial_pos : Vector2
@@ -23,12 +22,11 @@ func is_correct_placement(body):
 		print("Reject: Cannot move connecting piece")
 		return false
  
-	print("is_inside_dropable: ", is_inside_dropable)
 	print("is_inside_forbidden: ", is_inside_forbidden)
 	print("\n-----\n")
 	print(body_area2D.get_overlapping_areas())
 	print("\n-----\n")
-	if is_inside_dropable and not is_inside_forbidden:
+	if not is_inside_forbidden:
 		# gets Area2D child, which can check for overlapping bodies
 		var animal_type : String = Global.get_animal_type(body)
 		
@@ -182,7 +180,6 @@ func body_entered(body):
 	# set inside dropable to true so the process can register it as a dropable zone
 	# and change the colour of the body we just touched to signify we can drop it here
 	if body.is_in_group('dropable') and not body == self:
-		is_inside_dropable = true
 		body.modulate = TRIGGERED_COLOR
 	# "not body self" prevents some unexpected results with overlapping collision zones
 	# of self, but may also be a problem in the future 
@@ -195,7 +192,6 @@ func body_exited(body):
 	# if the snake body stops touching a staticbody that has the dropable group
 	# set inside dropable to false & change the colour of that body back to original 
 	if body.is_in_group('dropable') and not body == self:
-		is_inside_dropable = false
 		body.modulate = STANDARD_COLOR
 	# "not body self" prevents some unexpected results with overlapping collision zones
 	# of self, but may also be a problem in the future 

--- a/Arch-enemies/bridges/script/drag_handler.gd
+++ b/Arch-enemies/bridges/script/drag_handler.gd
@@ -25,16 +25,23 @@ func is_correct_placement(body):
  
 	print("is_inside_dropable: ", is_inside_dropable)
 	print("is_inside_forbidden: ", is_inside_forbidden)
-	print("\n")
+	print("\n-----\n")
+	print(body_area2D.get_overlapping_areas())
+	print("\n-----\n")
 	if is_inside_dropable and not is_inside_forbidden:
 		# gets Area2D child, which can check for overlapping bodies
 		var animal_type : String = Global.get_animal_type(body)
 		
-		# check if head of snake is overlapping with anything
+		# check if head of snake is overlapping with an animal
 		if animal_type == "snake":
-			if body.get_node("forbidden_Area2D").has_overlapping_bodies():
-				print("Reject: Head of snake overlaps")
-				return false
+			for overlapping_body in body.get_node("forbidden_Area2D").get_overlapping_bodies():
+				if (overlapping_body.is_in_group("snake") 
+					or overlapping_body.is_in_group("spider") 
+					or overlapping_body.is_in_group("squirrel")
+					or overlapping_body.is_in_group("deer")):
+					print(body.get_node("forbidden_Area2D").get_overlapping_bodies())
+					print("Reject: Head of snake overlaps")
+					return false
 		
 		# iterate through all overlapping bodies, and check if they are allowed or not
 		for overlapping_body in body_area2D.get_overlapping_bodies():
@@ -193,7 +200,7 @@ func body_exited(body):
 	# "not body self" prevents some unexpected results with overlapping collision zones
 	# of self, but may also be a problem in the future 
 	if body.is_in_group('forbidden') and not body == self:
-		print("left forbidden body ", body)
+		print("Left forbidden body ", body)
 		is_inside_forbidden = false
 
 

--- a/Arch-enemies/bridges/script/drag_handler.gd
+++ b/Arch-enemies/bridges/script/drag_handler.gd
@@ -18,9 +18,14 @@ var someone_connects_to_this = false
 
 # checks if placement of animal relativ to other animal is correct
 func is_correct_placement(body):
-	if body.someone_connects_to_this:		# if another animal holds on to this one it cant move
+	# if another animal holds on to this one it cant move
+	if body.someone_connects_to_this:
+		print("Reject: Cannot move connecting piece")
 		return false
  
+	print("is_inside_dropable: ", is_inside_dropable)
+	print("is_inside_forbidden: ", is_inside_forbidden)
+	print("\n")
 	if is_inside_dropable and not is_inside_forbidden:
 		# gets Area2D child, which can check for overlapping bodies
 		var animal_type : String = Global.get_animal_type(body)
@@ -28,17 +33,21 @@ func is_correct_placement(body):
 		# check if head of snake is overlapping with anything
 		if animal_type == "snake":
 			if body.get_node("forbidden_Area2D").has_overlapping_bodies():
+				print("Reject: Head of snake overlaps")
 				return false
 		
 		# iterate through all overlapping bodies, and check if they are allowed or not
 		for overlapping_body in body_area2D.get_overlapping_bodies():
 			# if overlapping body is a forbidden one, it is never valid
 			if overlapping_body.is_in_group("forbidden"):
+				print("Reject: is inside forbidden")
 				return false
 			
 			# if overlapping body is dropable and not its own, check specifics for animals
 			elif overlapping_body.is_in_group("dropable") and not body == overlapping_body.get_owner():
-				if not overlapping_body.is_in_group("shore_dropzone") and not overlapping_body.get_owner().is_bridge_connected_to_shore(): #if the overlapping_body is not connected to the shore the current animal cant be connected to it
+				 #if the overlapping_body is not connected to the shore the current animal cant be connected to it
+				if not overlapping_body.is_in_group("shore_dropzone") and not overlapping_body.get_owner().is_bridge_connected_to_shore():
+					print("Reject: Not connected to shore")
 					return false
 				if not overlapping_body.is_in_group("shore_dropzone"):  #the shore has no animal_type therefore this check has to be skipped 
 					# get type of animal that overlapping drop zone belongs to
@@ -46,22 +55,28 @@ func is_correct_placement(body):
 					# if overlap zone belongs to a spider, it is always allowed
 					if overlapping_animal_type == "spider":
 						body.connect_to_animal(overlapping_body)
+						print("Accept: Connected to spider")
 						return true
 					
 				# if not, normal rules apply
 				# every animal can be dropped on another animal's top dropzone
 				if overlapping_body.is_in_group("top_dropzone"):
 					body.connect_to_animal(overlapping_body)
+					print("Accept: On top dropzone of animal")
 					return true
 				# only squirrels and spiders can be dropped on another animal's side dropzones
 				elif overlapping_body.is_in_group("side_dropzone") and (animal_type == "squirrel" or animal_type == "spider"):
 					body.connect_to_animal(overlapping_body)
+					print("Accept: Squirrel on side dropzone of animal")
 					return true
 				# only spiders can be dropped on another animal's bottom dropzone
 				elif overlapping_body.is_in_group("bottom_dropzone") and animal_type == "spider":
 					body.connect_to_animal(overlapping_body)
+					print("Accept: Spider on bottom dropzone of animal")
 					return true
+		print("Reject: Not inside any recognized dropzone")
 		return false
+	print("Reject: Not inside dropable, or inside forbidden")
 	return false
 
 
@@ -165,6 +180,7 @@ func body_entered(body):
 	# "not body self" prevents some unexpected results with overlapping collision zones
 	# of self, but may also be a problem in the future 
 	if body.is_in_group('forbidden') and not body == self:
+		print("Entered forbidden body ", body)
 		is_inside_forbidden = true
 
 
@@ -177,6 +193,7 @@ func body_exited(body):
 	# "not body self" prevents some unexpected results with overlapping collision zones
 	# of self, but may also be a problem in the future 
 	if body.is_in_group('forbidden') and not body == self:
+		print("left forbidden body ", body)
 		is_inside_forbidden = false
 
 

--- a/Arch-enemies/bridges/script/drag_handler.gd
+++ b/Arch-enemies/bridges/script/drag_handler.gd
@@ -33,16 +33,18 @@ func is_correct_placement(body):
 		# check if head of snake is overlapping with an animal
 		if animal_type == "snake":
 			for overlapping_body in body.get_node("forbidden_Area2D").get_overlapping_bodies():
-				if (overlapping_body.is_in_group("snake") 
-					or overlapping_body.is_in_group("spider") 
+				print(body.get_node("forbidden_Area2D").get_overlapping_bodies())
+				if (overlapping_body.is_in_group("snake")
+					or overlapping_body.is_in_group("spider")
 					or overlapping_body.is_in_group("squirrel")
 					or overlapping_body.is_in_group("deer")):
-					print(body.get_node("forbidden_Area2D").get_overlapping_bodies())
 					print("Reject: Head of snake overlaps")
 					return false
+		
 		# checks for other animals beeing overlapped by the current placement
 		for area in body_area2D.get_overlapping_areas():
 			if(area.is_in_group("animal_body")):
+				print("Reject: Overlaps with animal")
 				return false
 		
 		# iterate through all overlapping bodies, and check if they are allowed or not

--- a/Arch-enemies/bridges/script/drag_handler.gd
+++ b/Arch-enemies/bridges/script/drag_handler.gd
@@ -21,19 +21,17 @@ func is_correct_placement(body):
 	if body.someone_connects_to_this:
 		print("Reject: Cannot move connecting piece")
 		return false
- 
-	print("is_inside_forbidden: ", is_inside_forbidden)
-	print("\n-----\n")
-	print(body_area2D.get_overlapping_areas())
-	print("\n-----\n")
+	
+	# check if body is inside a forbidden zone
 	if not is_inside_forbidden:
 		# gets Area2D child, which can check for overlapping bodies
 		var animal_type : String = Global.get_animal_type(body)
 		
 		# check if head of snake is overlapping with an animal
 		if animal_type == "snake":
+			# iterate through all bodies overlapping with the head collision zone
 			for overlapping_body in body.get_node("forbidden_Area2D").get_overlapping_bodies():
-				print(body.get_node("forbidden_Area2D").get_overlapping_bodies())
+				# check if root StaticBody2D belongs to an animal group
 				if (overlapping_body.is_in_group("snake")
 					or overlapping_body.is_in_group("spider")
 					or overlapping_body.is_in_group("squirrel")
@@ -41,7 +39,7 @@ func is_correct_placement(body):
 					print("Reject: Head of snake overlaps")
 					return false
 		
-		# checks for other animals beeing overlapped by the current placement
+		# checks for other animals being overlapped by the current placement
 		for area in body_area2D.get_overlapping_areas():
 			if(area.is_in_group("animal_body")):
 				print("Reject: Overlaps with animal")
@@ -54,8 +52,8 @@ func is_correct_placement(body):
 				print("Reject: is inside forbidden")
 				return false
 			
-			# if overlapping body is dropable and not its own, check specifics for animals
-			elif overlapping_body.is_in_group("dropable") and not body == overlapping_body.get_owner():
+			# if overlapping body is dropable, check specifics for animals
+			elif overlapping_body.is_in_group("dropable"):
 				 #if the overlapping_body is not connected to the shore the current animal cant be connected to it
 				if not overlapping_body.is_in_group("shore_dropzone") and not overlapping_body.get_owner().is_bridge_connected_to_shore():
 					print("Reject: Not connected to shore")
@@ -87,7 +85,7 @@ func is_correct_placement(body):
 					return true
 		print("Reject: Not inside any recognized dropzone")
 		return false
-	print("Reject: Not inside dropable, or inside forbidden")
+	print("Reject: Is inside forbidden")
 	return false
 
 
@@ -145,19 +143,24 @@ func connect_to_animal(overlapping_body):
 		overlapping_body.get_owner().someone_connects_to_this = true
 		
 
-func is_bridge_connected_to_shore():	#checks recursivly if an animal is connected to the shore through other animals
+
+# checks recursivly if an animal is connected to the shore through other animals
+func is_bridge_connected_to_shore():
 	print("self animal type:",Global.get_animal_type(self))
-	
-	if self.connected_to == null:								#connected to nothing
+	#connected to nothing
+	if self.connected_to == null:
 		print("is_bridge_connected_to_shore null False")
 		return false
 	else:
-		if self.connected_to.is_in_group("shore_dropzone"): 	# end of recursion connected to the shore
+		# end of recursion connected to the shore
+		if self.connected_to.is_in_group("shore_dropzone"):
 			print("is_bridge_connected_to_shore connected_to: shore")
 			return true
-		else:													#connected to another animal
+		#connected to another animal
+		else:
 			print("is_bridge_connected_to_shore connected_to:",Global.get_animal_type( self.connected_to.get_owner() ))
 			return self.connected_to.get_owner().is_bridge_connected_to_shore()
+
 
 func _on_area_2d_mouse_entered():
 	mouse_entered()
@@ -181,27 +184,23 @@ func mouse_exited():
 
 
 func body_entered(body):
-	# if the snake body touches a staticbody hitbox (body)
-	# and this body is in the group drobable
-	# set inside dropable to true so the process can register it as a dropable zone
-	# and change the colour of the body we just touched to signify we can drop it here
-	if body.is_in_group('dropable') and not body == self:
+	# if body stops touching a staticbody that has the dropable group
+	# change the colour of that body
+	if body.is_in_group('dropable'):
 		body.modulate = TRIGGERED_COLOR
-	# "not body self" prevents some unexpected results with overlapping collision zones
-	# of self, but may also be a problem in the future 
-	if body.is_in_group('forbidden') and not body == self:
+	# if body stops touching a forbidden group, update the variable
+	if body.is_in_group('forbidden'):
 		print("Entered forbidden body ", body)
 		is_inside_forbidden = true
 
 
 func body_exited(body):
-	# if the snake body stops touching a staticbody that has the dropable group
-	# set inside dropable to false & change the colour of that body back to original 
-	if body.is_in_group('dropable') and not body == self:
+	# if body stops touching a staticbody that has the dropable group
+	# change the colour of that body back to original 
+	if body.is_in_group('dropable'):
 		body.modulate = STANDARD_COLOR
-	# "not body self" prevents some unexpected results with overlapping collision zones
-	# of self, but may also be a problem in the future 
-	if body.is_in_group('forbidden') and not body == self:
+	# if body stops touching a forbidden group, update the variable 
+	if body.is_in_group('forbidden'):
 		print("Left forbidden body ", body)
 		is_inside_forbidden = false
 

--- a/Arch-enemies/bridges/script/drag_handler.gd
+++ b/Arch-enemies/bridges/script/drag_handler.gd
@@ -47,13 +47,8 @@ func is_correct_placement(body):
 		
 		# iterate through all overlapping bodies, and check if they are allowed or not
 		for overlapping_body in body_area2D.get_overlapping_bodies():
-			# if overlapping body is a forbidden one, it is never valid
-			if overlapping_body.is_in_group("forbidden"):
-				print("Reject: is inside forbidden")
-				return false
-			
 			# if overlapping body is dropable, check specifics for animals
-			elif overlapping_body.is_in_group("dropable"):
+			if overlapping_body.is_in_group("dropable"):
 				 #if the overlapping_body is not connected to the shore the current animal cant be connected to it
 				if not overlapping_body.is_in_group("shore_dropzone") and not overlapping_body.get_owner().is_bridge_connected_to_shore():
 					print("Reject: Not connected to shore")


### PR DESCRIPTION
## Motivation
closes #157

## What was changed/added
The hitbox of the snake head was adjusted to prevent bugs concerning falsely detecting collisions with it. Likewise, all central animal hitboxes have been adjusted, preventing bugs concercing falsely detecting collisons with itself. Additionally, ``is_inside_dropable`` was removed, as it served so purpose in the current approach. The functionality from #164 (which was deleted by #166) was re-added and greatly improved, and shouldn't cause bugs now. I also removed a duplicated (and non-functional) check for forbidden zones, as this only causes confusion. Some print statements were added to aid future debugging.

## Testing
Every placement works as intended, however the bug mentioned in #158 is predicatably still there.

[everythings works no bugs](https://github.com/mango-gremlin/arch-enemies/assets/104799849/9a4a3401-0fa0-4234-838e-96efb6848a05)

Here you can see that the snake's head works again.

[forbidden zones work](https://github.com/mango-gremlin/arch-enemies/assets/104799849/6a77e1bc-7d30-40dd-a49a-b60f6231d120)

Feel free to test for more snapping bugs in my branch, just in case I've missed something. 

## Additional Information
If PR #181 is implemented, this PR should likely be closed, as it fixes bugs in the current approach only.

Originally, I planned a larger refactor of the ``is_correct_placement`` function, but as this might become obsolete if #181 is implemented, I decided not to work on this for now. Regardless, the code should be easy enough to understand as is. 
