### PR TITLE
Added pause-menu to bridge

### DIFF
--- a/Arch-enemies/bridges/scenes/bridge_1.tscn
+++ b/Arch-enemies/bridges/scenes/bridge_1.tscn
@@ -12,7 +12,7 @@
 [ext_resource type="PackedScene" uid="uid://bqtg1c4s2pkab" path="res://bridges/scenes/animals/spider.tscn" id="11_daeky"]
 [ext_resource type="PackedScene" uid="uid://c5tl3m10s5tby" path="res://bridges/scenes/animals/snake.tscn" id="13_cijaf"]
 [ext_resource type="PackedScene" uid="uid://cbremi6mc4sua" path="res://bridges/scenes/world_edge.tscn" id="16_jmtqp"]
-[ext_resource type="PackedScene" uid="uid://cekfh8lbohea" path="res://bridges/scenes/shore.tscn" id="16_mfxt7"]
+[ext_resource type="PackedScene" path="res://bridges/scenes/shore.tscn" id="16_mfxt7"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_6rkrv"]
 size = Vector2(243.5, 45.4088)

--- a/Arch-enemies/bridges/script/player.gd
+++ b/Arch-enemies/bridges/script/player.gd
@@ -44,6 +44,10 @@ func _physics_process(delta):
 	else:
 		velocity.x = move_toward(velocity.x, 0, speed)
 	
+	# pressing esc -> pause-menu
+	if Input.is_action_just_pressed("open_menu"):
+		enter_pause_menu()
+	
 	move_and_slide()
 	update_animation()
 	update_facing_direction()
@@ -99,3 +103,15 @@ func _on_animated_sprite_2d_animation_finished():
 		animation_locked = false
 	elif animated_sprite.animation == "jump_up":
 		animated_sprite.play("jump_fly")
+
+
+func enter_pause_menu():
+	print("pause menu")
+	save_bridge()
+	# TODO ? (overworld team not happy with this but why?)
+	get_tree().change_scene_to_file("res://overworld/ui/menu/menu/pause_menu.tscn")
+
+# saves placed bridge 
+func save_bridge():
+	# TODO save what animals have been placed where 
+	print("save placed bridge")


### PR DESCRIPTION
## Motivation
closes #174 

The pause-menu in the overworld should also be in the bridge building scene.

## What was changed/added
I followed the same structure as in the overworld Player.gd to call the pause-menu scene.
Now you can open the pause-menue by pressing `esc` while in fox-mode.

## Testing

https://github.com/mango-gremlin/arch-enemies/assets/116217918/7d4c6804-17af-413d-ac98-29a31cd5fecd


## Additional Information
When opening the pause-menu you cannot go back to bridge building. This can either be fixed by changing the pause-menu scene to include an extra button (but what's the point of this button while pausing in the overworld?) or by creating a seperate pause-menu scene for the bridge building.

There is also the question if we should save the bridge build when using the pause-menu or not.
