### PR TITLE
Automatic assignment of shore dropzones

### DIFF
--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -37,11 +37,9 @@ var fox_start = [Vector2i(1,9), Vector2i(2,9), Vector2i(3,9), Vector2i(4,9),
 Vector2i(1,8), Vector2i(2,8), Vector2i(3,8), Vector2i(4,8),
 Vector2i(1,7), Vector2i(2,7), Vector2i(3,7), Vector2i(4,7)]
 
-# top shore dropzones (allowed)
-var shore_top = [Vector2i(0,12), Vector2i(1,12), Vector2i(2,12), Vector2i(3,12), Vector2i(4,12), Vector2i(5,12),
-Vector2i(33,12), Vector2i(34,12), Vector2i(35,12), Vector2i(36,12), Vector2i(37,12), Vector2i(38,12)]
-# side shore dropzones
-var shore_side = [Vector2i(6,13), Vector2i(6,14), Vector2i(32,13), Vector2i(32,14)]
+var shore_top = []
+var shore_side = []
+# = [Vector2i(6,13), Vector2i(6,14), Vector2i(32,13), Vector2i(32,14)]
 
 #This is the signal we use to transfer the current grid to child nodes
 signal current_grid(current_grid)
@@ -61,17 +59,42 @@ func _ready():
 			var square = Vector2i(x, y)
 			#If that tile is one of the ones we use for ground
 			var tile_id = get_cell_source_id(0, square)
-			#Which has ID 5
+			# which is contained in the tileset with id 11
 			if(tile_id == 11):
 				#We check what tile it is and add it as either GROUND or WATER to the grid
 				var atlas_field = get_cell_atlas_coords(0, square)
 				if(atlas_field in ground):
 					grid[x].append(ENTITY_TYPES.GROUND)
+					
+					# check if the tile above is in ground or water
+					var top_square = Vector2i(x, y - 1)
+					var top_square_atlas_field = get_cell_atlas_coords(0, top_square)
+					if (top_square_atlas_field not in ground 
+						and top_square_atlas_field not in water
+						and top_square.y >= 0):
+						shore_top.append(top_square)
+					
+					# check if the tile to the left is in ground or water
+					var left_square = Vector2i(x - 1, y)
+					var left_square_atlas_field = get_cell_atlas_coords(0, left_square)
+					if (left_square_atlas_field not in ground 
+						and left_square_atlas_field not in water
+						and left_square.x > 0):
+						print("left square added:\n", left_square, left_square_atlas_field)
+						shore_side.append(left_square)
+					
+					# check if the tile to the right is in ground or water
+					#var right_square = Vector2i(x + 1, y)
+					#var right_square_atlas_field = get_cell_atlas_coords(0, left_square)
+					#if (right_square_atlas_field not in ground 
+					#	and right_square_atlas_field not in water
+					#	and right_square.x < grid_size.x):
+					#	print("right square added:\n", right_square, right_square_atlas_field)
+					#	shore_side.append(right_square)
+					
 				elif(atlas_field in water):
 					grid[x].append(ENTITY_TYPES.WATER)
 			#Make the start tiles into allowed zones
-			elif(square in shore_top):
-				grid[x].append(ENTITY_TYPES.ALLOWED)
 			elif(square in shore_side):
 				grid[x].append(ENTITY_TYPES.CONDITIONAL) 
 			elif(square in fox_start):
@@ -80,6 +103,26 @@ func _ready():
 				#Currently every other tile becomes AIR
 				#This is subject to change
 				grid[x].append(ENTITY_TYPES.AIR)
+	
+	# assign shore dropzones
+	# needs to be a separate for loop, as grid is built dynamically, else we get index errors and overwritten content
+	# initiating grid before and preventing overlap for ALLOWED and CONDITIONAL is possible
+	print("shore_top: \n", shore_top)
+	for top_square in shore_top:
+		var x = top_square.x
+		var y = top_square.y
+		# checks if within bounds of grid
+		if x >= 0 and y >= 0 and x < grid_size.x and y < grid_size.y:
+			grid[x][y] = ENTITY_TYPES.ALLOWED
+	
+	print("shore_side: \n", shore_side)
+	for side_square in shore_side:
+		var x = side_square.x
+		var y = side_square.y
+		# checks if within bounds of grid
+		if x >= 0 and y >= 0 and x < grid_size.x and y < grid_size.y:
+			grid[x][y] = ENTITY_TYPES.CONDITIONAL
+
 	color_grid()
 	#Now we save the inital state of the grid for reset and previous state
 	start_grid = grid.duplicate(true)

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -68,34 +68,22 @@ func _ready():
 					
 					# check if the tile above is in ground or water
 					var top_square = Vector2i(x, y - 1)
-					var top_square_atlas_field = get_cell_atlas_coords(0, top_square)
-					if (top_square_atlas_field not in ground 
-						and top_square_atlas_field not in water
-						and top_square.y >= 0):
+					if is_shore_dropzone(top_square):
 						shore_top.append(top_square)
 					
 					# check if the tile below is in ground or water
 					var bottom_square = Vector2i(x, y + 1)
-					var bottom_square_atlas_field = get_cell_atlas_coords(0, bottom_square)
-					if (bottom_square_atlas_field not in ground 
-						and bottom_square_atlas_field not in water
-						and bottom_square.y < grid_size.y):
+					if is_shore_dropzone(bottom_square):
 						shore_bottom.append(bottom_square)
 					
 					# check if the tile to the left is in ground or water
 					var left_square = Vector2i(x - 1, y)
-					var left_square_atlas_field = get_cell_atlas_coords(0, left_square)
-					if (left_square_atlas_field not in ground 
-						and left_square_atlas_field not in water
-						and left_square.x > 0):
+					if is_shore_dropzone(left_square):
 						shore_side.append(left_square)
 					
 					# check if the tile to the right is in ground or water
 					var right_square = Vector2i(x + 1, y)
-					var right_square_atlas_field = get_cell_atlas_coords(0, right_square)
-					if (right_square_atlas_field not in ground 
-						and right_square_atlas_field not in water
-						and right_square.x < grid_size.x):
+					if is_shore_dropzone(right_square):
 						shore_side.append(right_square)
 					
 				elif(atlas_field in water):
@@ -111,34 +99,33 @@ func _ready():
 				grid[x].append(ENTITY_TYPES.AIR)
 	
 	# assign shore dropzones
-	for top_square in shore_top:
-		var x = top_square.x
-		var y = top_square.y
-		# checks if within bounds of grid
-		if x >= 0 and y >= 0 and x < grid_size.x and y < grid_size.y:
-			grid[x][y] = ENTITY_TYPES.ALLOWED
+	grid = assign_shore_dropzones(grid, shore_top, ENTITY_TYPES.ALLOWED)
 	# assign to SIDE in #199
-	for side_square in shore_side:
-		var x = side_square.x
-		var y = side_square.y
-		# checks if within bounds of grid
-		if x >= 0 and y >= 0 and x < grid_size.x and y < grid_size.y:
-			grid[x][y] = ENTITY_TYPES.CONDITIONAL
-	
+	grid = assign_shore_dropzones(grid, shore_side, ENTITY_TYPES.CONDITIONAL)
 	# assign to BOTTOM in #99
-	for bottom_square in shore_bottom:
-		var x = bottom_square.x
-		var y = bottom_square.y
-		# checks if within bounds of grid
-		if x >= 0 and y >= 0 and x < grid_size.x and y < grid_size.y:
-			grid[x][y] = ENTITY_TYPES.CONDITIONAL
-	
+	grid = assign_shore_dropzones(grid, shore_bottom, ENTITY_TYPES.CONDITIONAL)
 
 	color_grid()
 	#Now we save the inital state of the grid for reset and previous state
 	start_grid = grid.duplicate(true)
 	last_states[0] = grid.duplicate(true)
-	
+
+# iterates through list and assignes all squares to desired type
+func assign_shore_dropzones(grid:Array, squares:Array, type:ENTITY_TYPES) -> Array:
+	for square in squares:
+		grid[square.x][square.y] = type
+	return grid
+
+# checks if square isn't in ground or water, and is within grid bounds
+func is_shore_dropzone(square:Vector2i) -> bool:
+	var atlas_field = get_cell_atlas_coords(0, square)
+	if (atlas_field not in ground 
+		and atlas_field not in water
+		and square.x >= 0 and square.y >= 0
+		and square.x < grid_size.x and square.y < grid_size.y):
+		return true
+	return false
+
 func color_grid():
 	#This function colors the grid cells that are not predefined, i.e. the background
 	#We iterate over all the cells

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -88,9 +88,6 @@ func _ready():
 					
 				elif(atlas_field in water):
 					grid[x].append(ENTITY_TYPES.WATER)
-			#Make the start tiles into allowed zones
-			elif(square in shore_side):
-				grid[x].append(ENTITY_TYPES.CONDITIONAL) 
 			elif(square in fox_start):
 				grid[x].append(ENTITY_TYPES.FORBIDDEN)
 			else:

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -39,7 +39,7 @@ Vector2i(1,7), Vector2i(2,7), Vector2i(3,7), Vector2i(4,7)]
 
 var shore_top = []
 var shore_side = []
-# = [Vector2i(6,13), Vector2i(6,14), Vector2i(32,13), Vector2i(32,14)]
+var shore_bottom = []
 
 #This is the signal we use to transfer the current grid to child nodes
 signal current_grid(current_grid)
@@ -74,23 +74,29 @@ func _ready():
 						and top_square.y >= 0):
 						shore_top.append(top_square)
 					
+					# check if the tile below is in ground or water
+					var bottom_square = Vector2i(x, y + 1)
+					var bottom_square_atlas_field = get_cell_atlas_coords(0, bottom_square)
+					if (bottom_square_atlas_field not in ground 
+						and bottom_square_atlas_field not in water
+						and bottom_square.y < grid_size.y):
+						shore_bottom.append(bottom_square)
+					
 					# check if the tile to the left is in ground or water
 					var left_square = Vector2i(x - 1, y)
 					var left_square_atlas_field = get_cell_atlas_coords(0, left_square)
 					if (left_square_atlas_field not in ground 
 						and left_square_atlas_field not in water
 						and left_square.x > 0):
-						print("left square added:\n", left_square, left_square_atlas_field)
 						shore_side.append(left_square)
 					
 					# check if the tile to the right is in ground or water
-					#var right_square = Vector2i(x + 1, y)
-					#var right_square_atlas_field = get_cell_atlas_coords(0, left_square)
-					#if (right_square_atlas_field not in ground 
-					#	and right_square_atlas_field not in water
-					#	and right_square.x < grid_size.x):
-					#	print("right square added:\n", right_square, right_square_atlas_field)
-					#	shore_side.append(right_square)
+					var right_square = Vector2i(x + 1, y)
+					var right_square_atlas_field = get_cell_atlas_coords(0, right_square)
+					if (right_square_atlas_field not in ground 
+						and right_square_atlas_field not in water
+						and right_square.x < grid_size.x):
+						shore_side.append(right_square)
 					
 				elif(atlas_field in water):
 					grid[x].append(ENTITY_TYPES.WATER)
@@ -105,23 +111,28 @@ func _ready():
 				grid[x].append(ENTITY_TYPES.AIR)
 	
 	# assign shore dropzones
-	# needs to be a separate for loop, as grid is built dynamically, else we get index errors and overwritten content
-	# initiating grid before and preventing overlap for ALLOWED and CONDITIONAL is possible
-	print("shore_top: \n", shore_top)
 	for top_square in shore_top:
 		var x = top_square.x
 		var y = top_square.y
 		# checks if within bounds of grid
 		if x >= 0 and y >= 0 and x < grid_size.x and y < grid_size.y:
 			grid[x][y] = ENTITY_TYPES.ALLOWED
-	
-	print("shore_side: \n", shore_side)
+	# assign to SIDE in #199
 	for side_square in shore_side:
 		var x = side_square.x
 		var y = side_square.y
 		# checks if within bounds of grid
 		if x >= 0 and y >= 0 and x < grid_size.x and y < grid_size.y:
 			grid[x][y] = ENTITY_TYPES.CONDITIONAL
+	
+	# assign to BOTTOM in #99
+	for bottom_square in shore_bottom:
+		var x = bottom_square.x
+		var y = bottom_square.y
+		# checks if within bounds of grid
+		if x >= 0 and y >= 0 and x < grid_size.x and y < grid_size.y:
+			grid[x][y] = ENTITY_TYPES.CONDITIONAL
+	
 
 	color_grid()
 	#Now we save the inital state of the grid for reset and previous state

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -36,8 +36,12 @@ Vector2i(7, 8), Vector2i(8, 8), Vector2i(7, 9), Vector2i(8, 9), Vector2i(5, 8), 
 var fox_start = [Vector2i(1,9), Vector2i(2,9), Vector2i(3,9), Vector2i(4,9),
 Vector2i(1,8), Vector2i(2,8), Vector2i(3,8), Vector2i(4,8),
 Vector2i(1,7), Vector2i(2,7), Vector2i(3,7), Vector2i(4,7)]
-				
-var start_zone = [Vector2i(3,12),Vector2i(4,12),Vector2i(5,12)]
+
+# top shore dropzones (allowed)
+var shore_top = [Vector2i(0,12), Vector2i(1,12), Vector2i(2,12), Vector2i(3,12), Vector2i(4,12), Vector2i(5,12),
+Vector2i(33,12), Vector2i(34,12), Vector2i(35,12), Vector2i(36,12), Vector2i(37,12), Vector2i(38,12)]
+# side shore dropzones
+var shore_side = [Vector2i(6,13), Vector2i(6,14), Vector2i(32,13), Vector2i(32,14)]
 
 #This is the signal we use to transfer the current grid to child nodes
 signal current_grid(current_grid)
@@ -66,8 +70,10 @@ func _ready():
 				elif(atlas_field in water):
 					grid[x].append(ENTITY_TYPES.WATER)
 			#Make the start tiles into allowed zones
-			elif(square in start_zone):
+			elif(square in shore_top):
 				grid[x].append(ENTITY_TYPES.ALLOWED)
+			elif(square in shore_side):
+				grid[x].append(ENTITY_TYPES.CONDITIONAL) 
 			elif(square in fox_start):
 				grid[x].append(ENTITY_TYPES.FORBIDDEN)
 			else:


### PR DESCRIPTION
## Motivation
closes #210 

## What was changed/added
Shore dropzones are automatically assigned, via the following procedure.
During ``_ready``, whenever iterating over a square belonging to a ground tile, check if its adjacent squares (top, right, bottom, left) are in the air (in other words, not ground or water), and within grid bounds (to prevent errors). If they are, add them to their respective list (``shore_top``, ``shore_side``, ``shore_bottom``), depending on their relative position. After the grid has been initialized, iterate over these list and assign them their respective ``ENTITY_TYPE``. As the grid is filled slowly, and not initialized, it was not possible to assign them in the for loop (cells didn't exist, and code currently allows for overwrites), hence the added function.

## Testing
As you can see, all dropzones are rendered and work as expected, without hardcoding them. Note that I edited the Tilemap for this, to show that overhangs also work. The tilemap edit was only done for testing, as is not included in the commit.

[Automatic Assignment of Shore Dropzones](https://github.com/mango-gremlin/arch-enemies/assets/104799849/f0a078be-8a41-4cd0-8831-d5f81ea5fe90)



## Additional Information
I decided against using a tilemap based approach, as this would likely interfere with the current assignment of the grid, and because this approach reduces work required for future levels, by making dropzones automatic.

Also, one could use this code as a basis for implementing hazard zones, by checking adjecant tiles to hazards and flagging them accordingly.

It should be noted that this includes merely the dropzones, and not the initial zones of the fox. This should be done in a future issue, which could also adress some refactoring regarding the initial position (setting position as property, and computing zones from there, for example). 

## Future improvements
I propose splitting the tilemap in two distinct tilemaps; one for ground and one for water. This would require some minor refactoring, but importantly get rid of the hideous hardcoding in line 21 onwards, which is bound to cause some trouble if someone ever edits the tileset in the future. 

@aylinfi, for issue #199, simply edit the lines deciding where dropzones should be tagged. Currently this is 104 and 106. Every other part of the code has been written with the distinction in mind.
