### PR TITLE
Issue213/auto fox startzone

### DIFF
--- a/Arch-enemies/bridges/scenes/Grid.tscn
+++ b/Arch-enemies/bridges/scenes/Grid.tscn
@@ -681,7 +681,7 @@ scale = Vector2(0.5, 0.5)
 text = "One Step Back"
 
 [node name="Player" parent="Grid" instance=ExtResource("12_y7gdk")]
-position = Vector2(29, 85)
+position = Vector2(30, 82)
 
 [node name="water_detection" parent="Grid" instance=ExtResource("14_yxqwc")]
 

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -97,15 +97,14 @@ func _ready():
 	
 	# get position of fox
 	var fox_global_position = $Player.global_position
-	print(fox_global_position)
-	# round to nearest square. may improve this later with round_to_nearest
-	var fox_grid_position = Vector2i(int(fox_global_position.x/10), int(fox_global_position.y/10))
-	print(fox_grid_position)
+	# round to nearest square
+	var fox_grid_x = Global.round_to_nearest(fox_global_position.x, 10) / 10
+	var fox_grid_y = Global.round_to_nearest(fox_global_position.y, 10) / 10
+	var fox_grid_position = Vector2i(fox_grid_x, fox_grid_y)
+	
 	# iterate over 4x3 squares with (1,2) being fox centre
 	for x_offset in range(-2,2):
-		print("\nx_offset: ", x_offset)
 		for y_offset in range(-1,2):
-			print("y_offset: ", y_offset)
 			var crt_square = Vector2i(fox_grid_position.x + x_offset, fox_grid_position.y + y_offset)
 			grid[crt_square.x][crt_square.y] = ENTITY_TYPES.FORBIDDEN
 	

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -96,22 +96,7 @@ func _ready():
 	# assign to BOTTOM in #199
 	grid = assign_shore_dropzones(grid, shore_bottom, ENTITY_TYPES.CONDITIONAL)
 	
-	# assign forbidden zones around fox sprite
-	
-	# get position of fox
-	var fox_global_position = $Player.global_position
-	
-	# round to nearest grid square
-	var fox_grid_x = Global.round_to_nearest(fox_global_position.x, square_size) / square_size
-	var fox_grid_y = Global.round_to_nearest(fox_global_position.y, square_size) / square_size
-	var fox_grid_position = Vector2i(fox_grid_x, fox_grid_y)
-	
-	# iterate over 4x3 squares with (1,2) being fox centre
-	for x_offset in range(-2,2):
-		for y_offset in range(-1,2):
-			var crt_square = Vector2i(fox_grid_position.x + x_offset, fox_grid_position.y + y_offset)
-			# assign each square as forbidden
-			grid[crt_square.x][crt_square.y] = ENTITY_TYPES.FORBIDDEN
+	grid = assign_fox_forbidden_zones(grid)
 	
 	color_grid()
 	#Now we save the inital state of the grid for reset and previous state
@@ -133,6 +118,24 @@ func is_shore_dropzone(square:Vector2i) -> bool:
 		and square.x < grid_size.x and square.y < grid_size.y):
 		return true
 	return false
+
+# takes grid as input, assigns forbidden zones around the fox sprite
+func assign_fox_forbidden_zones(grid:Array) -> Array:
+	# get position of fox
+	var fox_global_position = $Player.global_position
+	
+	# round to nearest grid square
+	var fox_grid_x = Global.round_to_nearest(fox_global_position.x, square_size) / square_size
+	var fox_grid_y = Global.round_to_nearest(fox_global_position.y, square_size) / square_size
+	var fox_grid_position = Vector2i(fox_grid_x, fox_grid_y)
+	
+	# iterate over 4x3 squares with (1,2) being fox centre
+	for x_offset in range(-2,2):
+		for y_offset in range(-1,2):
+			var crt_square = Vector2i(fox_grid_position.x + x_offset, fox_grid_position.y + y_offset)
+			# assign each square as forbidden
+			grid[crt_square.x][crt_square.y] = ENTITY_TYPES.FORBIDDEN
+	return grid
 
 func color_grid():
 	#This function colors the grid cells that are not predefined, i.e. the background

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -1,6 +1,6 @@
 extends TileMap
 
-#We define the basical variables here
+#We define the basic variables here
 
 #Like the Tile Size
 var tile_size = tile_set.tile_size
@@ -31,11 +31,6 @@ Vector2i(6, 7), Vector2i(1, 5), Vector2i(2, 5), Vector2i(3, 5), Vector2i(1, 6), 
 Vector2i(3, 6), Vector2i(1, 7), Vector2i(2, 7), Vector2i(3, 7), Vector2i(0, 8), Vector2i(0, 9),
 Vector2i(1, 9), Vector2i(2, 9), Vector2i(3, 9), Vector2i(4, 9), Vector2i(7, 7), Vector2i(8, 7),
 Vector2i(7, 8), Vector2i(8, 8), Vector2i(7, 9), Vector2i(8, 9), Vector2i(5, 8), Vector2i(5, 9)]
-
-#And the start zone for the Fox
-var fox_start = [Vector2i(1,9), Vector2i(2,9), Vector2i(3,9), Vector2i(4,9),
-Vector2i(1,8), Vector2i(2,8), Vector2i(3,8), Vector2i(4,8),
-Vector2i(1,7), Vector2i(2,7), Vector2i(3,7), Vector2i(4,7)]
 
 var shore_top = []
 var shore_side = []
@@ -88,8 +83,6 @@ func _ready():
 					
 				elif(atlas_field in water):
 					grid[x].append(ENTITY_TYPES.WATER)
-			elif(square in fox_start):
-				grid[x].append(ENTITY_TYPES.FORBIDDEN)
 			else:
 				#Currently every other tile becomes AIR
 				#This is subject to change
@@ -101,7 +94,21 @@ func _ready():
 	grid = assign_shore_dropzones(grid, shore_side, ENTITY_TYPES.CONDITIONAL)
 	# assign to BOTTOM in #99
 	grid = assign_shore_dropzones(grid, shore_bottom, ENTITY_TYPES.CONDITIONAL)
-
+	
+	# get position of fox
+	var fox_global_position = $Player.global_position
+	print(fox_global_position)
+	# round to nearest square. may improve this later with round_to_nearest
+	var fox_grid_position = Vector2i(int(fox_global_position.x/10), int(fox_global_position.y/10))
+	print(fox_grid_position)
+	# iterate over 4x3 squares with (1,2) being fox centre
+	for x_offset in range(-2,2):
+		print("\nx_offset: ", x_offset)
+		for y_offset in range(-1,2):
+			print("y_offset: ", y_offset)
+			var crt_square = Vector2i(fox_grid_position.x + x_offset, fox_grid_position.y + y_offset)
+			grid[crt_square.x][crt_square.y] = ENTITY_TYPES.FORBIDDEN
+	
 	color_grid()
 	#Now we save the inital state of the grid for reset and previous state
 	start_grid = grid.duplicate(true)

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -8,6 +8,7 @@ var tile_size = tile_set.tile_size
 #The Dimensions of the Grid
 var x_size = 39
 var y_size = 22
+const square_size = 10
 
 #And finally some values we need later
 var grid_size = Vector2(x_size, y_size)
@@ -92,20 +93,24 @@ func _ready():
 	grid = assign_shore_dropzones(grid, shore_top, ENTITY_TYPES.ALLOWED)
 	# assign to SIDE in #199
 	grid = assign_shore_dropzones(grid, shore_side, ENTITY_TYPES.CONDITIONAL)
-	# assign to BOTTOM in #99
+	# assign to BOTTOM in #199
 	grid = assign_shore_dropzones(grid, shore_bottom, ENTITY_TYPES.CONDITIONAL)
+	
+	# assign forbidden zones around fox sprite
 	
 	# get position of fox
 	var fox_global_position = $Player.global_position
-	# round to nearest square
-	var fox_grid_x = Global.round_to_nearest(fox_global_position.x, 10) / 10
-	var fox_grid_y = Global.round_to_nearest(fox_global_position.y, 10) / 10
+	
+	# round to nearest grid square
+	var fox_grid_x = Global.round_to_nearest(fox_global_position.x, square_size) / square_size
+	var fox_grid_y = Global.round_to_nearest(fox_global_position.y, square_size) / square_size
 	var fox_grid_position = Vector2i(fox_grid_x, fox_grid_y)
 	
 	# iterate over 4x3 squares with (1,2) being fox centre
 	for x_offset in range(-2,2):
 		for y_offset in range(-1,2):
 			var crt_square = Vector2i(fox_grid_position.x + x_offset, fox_grid_position.y + y_offset)
+			# assign each square as forbidden
 			grid[crt_square.x][crt_square.y] = ENTITY_TYPES.FORBIDDEN
 	
 	color_grid()


### PR DESCRIPTION
## Motivation
closes #213


## What was changed/added
4x3 forbidden zone around the fox starting position is now automatically assigned. This is done by getting the grid square that is nearest to the fox central position, and assigning ``FORBIDDEN`` to all adjacent squares in a 4x3 box (with the central square being 1,2). The conversion from global position in pixels to grid position can lead to the forbidden box being a bit off the actual sprite. As there's nothing one really can do against that (at least not with a simple fix), just drag the fox to a spot where it makes sense. 

## Testing
Here we can see the forbidden box without hardcoding anything.
![image](https://github.com/mango-gremlin/arch-enemies/assets/104799849/f8fbc12c-4d3e-4411-babb-fd5525d41221)


Here we can see one example where the box is a little bit off due to conversion. In this case, drag the fox a bit up or down. 
![image](https://github.com/mango-gremlin/arch-enemies/assets/104799849/5d5740f5-0b11-4c54-bf4e-137ff7913145)

## Additional Information
I mentioned in #213 that exporting the fox' starting position might be good idea, but now I think that simply dragging the fog within the scene is easier for creating levels. If you want to change that, feel free to do so, that takes like 2 minutes.
