### PR TITLE
overworld | autoloading sprites for npcs

### DIFF
--- a/Arch-enemies/overworld/entities/interaction_overworld/npc_interaction.gd
+++ b/Arch-enemies/overworld/entities/interaction_overworld/npc_interaction.gd
@@ -113,13 +113,13 @@ func set_npc_sprite():
 	var path_to_sprite:String 
 	match npc_animal_type:
 		Animal.AnimalType.SNAKE: 
-			path_to_sprite = "res://assets/art/objects/bridge_snake.png"
+			path_to_sprite = "res://assets/art/characters/snek.png"
 		Animal.AnimalType.DEER:
-			path_to_sprite = "res://assets/art/objects/bridge_deer.png"
+			path_to_sprite = "res://assets/art/characters/deer.png"
 		Animal.AnimalType.SQUIRREL: 
-			path_to_sprite = "res://assets/art/objects/bridge_squirrel.png"
+			path_to_sprite = "res://assets/art/characters/squirrel.png"
 		Animal.AnimalType.SPIDER:
-			path_to_sprite = "res://assets/art/objects/bridge_spider.png"
+			path_to_sprite = "res://assets/art/characters/spider.png"
 	# loading texture 
 	var npc_sprite:Texture2D = load(path_to_sprite)
 	referenced_sprite.texture = npc_sprite

--- a/Arch-enemies/overworld/entities/interaction_overworld/npc_interaction.gd
+++ b/Arch-enemies/overworld/entities/interaction_overworld/npc_interaction.gd
@@ -16,11 +16,17 @@ extends Node2D
 @export var quest_reward:NPC_interaction.QuestReward = NPC_interaction.QuestReward.NONE
 @export var reward_item:Item.ItemType = Item.ItemType.NONE
 
+# VISUALIZATION 
+# only set whenever a special sprite is required for this npc!
+@export var npc_special_sprite:Texture2D 
+
 # denotes NPC object tied to this node 
 var interaction_type: Interactable.InteractionType = Interactable.InteractionType.NPC
 @onready var npc_object:NPC_interaction 
 
 func _ready():
+	# load visualization 
+	set_npc_sprite()
 	# constructing NPC accordingly
 	npc_object = NPC_interaction.new(npc_name,npc_id,npc_animal_type)
 	
@@ -91,3 +97,29 @@ func set_quest_resolved():
 func obtain_required_item() -> Item.ItemType:
 	return required_item
 
+# --- / 
+# -- / VISUALIZATION
+# this section is for visualization within the overworld 
+
+# deriving sprite to load from animal type
+# OR a set special_sprite 
+func set_npc_sprite():
+	# initialize reference
+	var referenced_sprite:Sprite2D = $Sprite2D
+	
+	if npc_special_sprite != null:
+		referenced_sprite.texture = npc_special_sprite
+		return
+	var path_to_sprite:String 
+	match npc_animal_type:
+		Animal.AnimalType.SNAKE: 
+			path_to_sprite = "res://assets/art/objects/bridge_snake.png"
+		Animal.AnimalType.DEER:
+			path_to_sprite = "res://assets/art/objects/bridge_deer.png"
+		Animal.AnimalType.SQUIRREL: 
+			path_to_sprite = "res://assets/art/objects/bridge_squirrel.png"
+		Animal.AnimalType.SPIDER:
+			path_to_sprite = "res://assets/art/objects/bridge_spider.png"
+	# loading texture 
+	var npc_sprite:Texture2D = load(path_to_sprite)
+	referenced_sprite.texture = npc_sprite

--- a/Arch-enemies/overworld/entities/interaction_overworld/npc_interaction.tscn
+++ b/Arch-enemies/overworld/entities/interaction_overworld/npc_interaction.tscn
@@ -15,6 +15,7 @@ flip_h = true
 [node name="interactionspot" parent="." instance=ExtResource("2_y76uy")]
 
 [node name="ColorRect" type="ColorRect" parent="."]
+visible = false
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5

--- a/Arch-enemies/overworld/main_scene_overworld.tscn
+++ b/Arch-enemies/overworld/main_scene_overworld.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://cgfkelxiskcux"]
+[gd_scene load_steps=10 format=3 uid="uid://cgfkelxiskcux"]
 
 [ext_resource type="Script" path="res://overworld/overworld.gd" id="1_pwtu4"]
 [ext_resource type="PackedScene" uid="uid://dndu4pg1i3tlf" path="res://overworld/scenes/player.tscn" id="2_mpe4y"]
@@ -7,6 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://bj3a1sw80l6wj" path="res://overworld/entities/interaction_overworld/item_interaction.tscn" id="6_66i44"]
 [ext_resource type="PackedScene" uid="uid://5llfgi2ysvie" path="res://overworld/entities/interaction_overworld/bridge_interaction.tscn" id="6_iairi"]
 [ext_resource type="PackedScene" uid="uid://drn1loe1wknbq" path="res://overworld/entities/interaction_overworld/npc_interaction.tscn" id="7_33ud0"]
+[ext_resource type="Texture2D" uid="uid://08plwlb60wib" path="res://assets/art/bridge_dummy_failure.png" id="8_g5nw6"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_25akq"]
 size = Vector2(36, 20)
@@ -121,5 +122,6 @@ position = Vector2(409, 335)
 npc_name = "esther"
 npc_id = 3
 npc_animal_type = 3
+npc_special_sprite = ExtResource("8_g5nw6")
 
 [connection signal="saved_player" from="Player" to="." method="_on_player_saved_player"]


### PR DESCRIPTION
## Motivation
resolves #224 
~~**requires** #232 !~~ was incorporated already, sorry!

## What was changed/added
Adds a method that runs upon **initialization** of a npc_interaction ( so the interactionspot within the overworld that denotes the npc interaction ) and then **loads/sets** the corresponding sprite for displaying said animal. 

Furthermore a new **exported variable** was defined that can be set to be **an invariante**, so  a special texture for a given npc. 

The method considers this invariant and prioritizes it over the default animal-sprites.

 

## Testing

The overworld now contains all the npc interactions with their corresponding sprites ( **not the final ones however** ):
![image](https://github.com/mango-gremlin/arch-enemies/assets/63316422/c96e63f6-aa4e-4616-ac11-411df4aa3280)

Furthermore in the lower corner an invariant was added ( Esther is a failed square now):
![image](https://github.com/mango-gremlin/arch-enemies/assets/63316422/4ed71d95-2e57-41f5-a789-332235fc081b)
