### PR TITLE
overworld | add methods to add/remove quests, add them to ui for tracking purpose

### DIFF
--- a/Arch-enemies/overworld/scripts/Npc.gd
+++ b/Arch-enemies/overworld/scripts/Npc.gd
@@ -98,6 +98,12 @@ func obtain_reward_type() -> NPC_interaction.QuestReward:
 func obtain_required_item() -> Item.ItemType:
 	return required_item
 
+# returns whether this npc holds a quest (!= NONE) 
+# or not 
+func has_quest() -> bool:
+	if quest_type != Quest.NONE:
+		return true
+	return false
 
 # --- / 
 # -- / quest behavior / interaction 
@@ -143,7 +149,9 @@ func set_quest_resolved():
 	quest_resolved = true 
 
 # checks whether conditions for completing quest were acquired 
-# updates "quest_resolved" accordingly
+# returns this state as boolean 
+# true if condition met
+# false otherwise
 func check_quest_condition() -> bool:
 	# FIXME IMPROVE WRITING / CONDITIONS 
 	if not quest_resolved : 
@@ -221,9 +229,8 @@ func stringify_quest() -> String:
 			var target_npc_name = target_npc.obtain_name()
 			requirement_string = " wants you to talk to " + target_npc_name 
 	
-	# done querying information based on type!
-	# WITH NAME BEFORE var combined_message = source_npc_name + requirement_string 
-	var combined_message = requirement_string 
+	# combine name of npc with its quest
+	var combined_message = source_npc_name + requirement_string 
 	return combined_message
 
 # --- / 

--- a/Arch-enemies/overworld/ui/overworld_ui/overworld_ui.gd
+++ b/Arch-enemies/overworld/ui/overworld_ui/overworld_ui.gd
@@ -13,21 +13,27 @@ func _ready():
 	# connecting signal to singleton
 	SingletonPlayer.connect("updated_item_inventory",_on_player_updated_inventory) 
 	SingletonPlayer.connect("updated_animal_inventory",_on_animal_inventory_updated)
+	SingletonPlayer.connect("updated_quest_list",_on_quest_list_updated)
 	# initialize ui
 	_update_item_inventory_label()
 	_update_animal_inventory_label()
 
 
 var player_item_inventory:Dictionary = {}:
-	set(newDict):
+	set(new_dict):
 		# if a new array was given, we update its value, also the label
-		player_item_inventory = newDict
+		player_item_inventory = new_dict
 		_update_item_inventory_label()
 
 var player_animal_inventory:Dictionary = {}:
-	set(newDict):
-		player_animal_inventory = newDict
+	set(new_dict):
+		player_animal_inventory = new_dict
 		_update_animal_inventory_label()
+
+var player_quest_dictionary:Dictionary = {}:
+	set(new_dict):
+		player_quest_dictionary = new_dict
+		_update_quest_list()
 
 func _update_item_inventory_label():
 	# iterate over item
@@ -46,9 +52,16 @@ func _update_animal_inventory_label():
 		var animal_name:String = Animal.type_to_string(animal)
 		label_string += str(animal_amount) + "x " + str(animal_name) + "\n"
 	animal_list_label.text = label_string
+
+# iterates over received list of quests
+# displays them formatted in newline 
+func _update_quest_list():
+	var label_string:String = ""
+	for quest_id:int in player_quest_dictionary:
+		var quest_string:String = player_quest_dictionary[quest_id]
 		
-		
-	
+		label_string += quest_string + "\n"
+	quest_list_label.text = label_string
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
@@ -61,3 +74,6 @@ func _on_player_updated_inventory(inventory):
 
 func _on_animal_inventory_updated(new_animal_inventory):
 	player_animal_inventory = new_animal_inventory
+
+func _on_quest_list_updated(new_quests):
+	player_quest_dictionary = new_quests


### PR DESCRIPTION

## Motivation
This pr aims to add a functionality to **visually** track Quests occurring in the overworld. 
Its done by adding a new dictionary within the singleton which will track / contain each quest as string ( linked to its npc_id ) 
resolves #191 
resolves #189 
## What was changed/added

-  added **Dictionary** `quest_string_dict` in singleton_player. 
- Its modified by `add_quest_string()` and `remove_quest_string()` which are adding / removing new entries 
- added signal to notify UI for quest-updates 
- modified `add_npc_talked_to` to accommodate adding / removing a quest upon interaction
- added new method to visualize quest in `overworldui` ( similar to the previous methods, primarily as dummy until UI was added ) 

## Testing

Ran it in the overworld with its default npcs: 
before submitting "Evillyn"s quest ( talking to esther) 
![image](https://github.com/mango-gremlin/arch-enemies/assets/63316422/b7adb26c-5f4f-496e-8ac6-6f98d8da214c)

after talking to "Evillyn" with submitted quest" 
![image](https://github.com/mango-gremlin/arch-enemies/assets/63316422/6d3b3934-3582-40fa-baa7-130fb338780d)

so far I have not noticed any issues with this approach. 
