### PR TITLE
Issue172/bridge inventory

### DIFF
--- a/Arch-enemies/bridges/scenes/Grid.tscn
+++ b/Arch-enemies/bridges/scenes/Grid.tscn
@@ -775,7 +775,7 @@ sources/6 = SubResource("TileSetAtlasSource_meq0p")
 position = Vector2(192, 108)
 zoom = Vector2(3, 3)
 
-[node name="Grid" type="TileMap" parent="."]
+[node name="Grid" type="TileMap" parent="." node_paths=PackedStringArray("inventory_deer", "inventory_snake", "inventory_spider", "inventory_squirrel")]
 tile_set = SubResource("TileSet_ne4ig")
 format = 2
 layer_0/name = "level"
@@ -783,6 +783,10 @@ layer_0/tile_data = PackedInt32Array(851968, 196610, 0, 851969, 65538, 0, 851970
 layer_1/name = "guidance"
 layer_1/tile_data = PackedInt32Array()
 script = ExtResource("1_xtvvi")
+inventory_deer = NodePath("animal_inventory_counter/deer")
+inventory_snake = NodePath("animal_inventory_counter/snake")
+inventory_spider = NodePath("animal_inventory_counter/spider")
+inventory_squirrel = NodePath("animal_inventory_counter/squirrel")
 
 [node name="Grid_Visualizer" type="Node2D" parent="Grid"]
 script = ExtResource("2_d8ovy")
@@ -885,6 +889,27 @@ size_flags_vertical = 4
 
 [node name="goal" parent="Grid" instance=ExtResource("16_f3lv2")]
 position = Vector2(340, 95)
+
+[node name="animal_inventory_counter" type="HBoxContainer" parent="Grid"]
+offset_top = 38.0
+offset_right = 52.0
+offset_bottom = 61.0
+
+[node name="deer" type="Label" parent="Grid/animal_inventory_counter"]
+layout_mode = 2
+text = "0"
+
+[node name="snake" type="Label" parent="Grid/animal_inventory_counter"]
+layout_mode = 2
+text = "0"
+
+[node name="spider" type="Label" parent="Grid/animal_inventory_counter"]
+layout_mode = 2
+text = "0"
+
+[node name="squirrel" type="Label" parent="Grid/animal_inventory_counter"]
+layout_mode = 2
+text = "0"
 
 [node name="parallax_background" parent="." instance=ExtResource("18_uekha")]
 

--- a/Arch-enemies/bridges/scenes/Grid.tscn
+++ b/Arch-enemies/bridges/scenes/Grid.tscn
@@ -21,7 +21,7 @@
 [ext_resource type="PackedScene" uid="uid://cxj1q08s3i7i8" path="res://bridges/scenes/goal_menu.tscn" id="15_sf441"]
 [ext_resource type="PackedScene" uid="uid://dfnsuounqjr4c" path="res://bridges/scenes/goal.tscn" id="16_f3lv2"]
 [ext_resource type="PackedScene" uid="uid://dcjyh0fonb2du" path="res://bridges/scenes/hazard_detection.tscn" id="18_r5eg5"]
-[ext_resource type="PackedScene" uid="uid://dynxnwixd1bke" path="res://bridges/scenes/parallax_background.tscn" id="18_uekha"]
+[ext_resource type="PackedScene" path="res://bridges/scenes/parallax_background.tscn" id="18_uekha"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_gxf1m"]
 texture = ExtResource("1_uowbf")

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -60,13 +60,17 @@ signal current_grid(current_grid)
 enum ENTITY_TYPES {GROUND, WATER, AIR, ANIMAL, FORBIDDEN, ALLOWED, SIDE, BOTTOM, SHALLOW}
 
 func _ready():
+	
+	SingletonPlayer.add_to_animal_inventory(Animal.AnimalType.DEER, 2)
+	SingletonPlayer.add_to_animal_inventory(Animal.AnimalType.SNAKE, 2)
+	
+	start_animals = SingletonPlayer.get_animal_inventory().duplicate(true)
 	#update the ui
 	update_inventory()
 	
 	#We save the previous states of the grid in an array, this array is initalized here
 	for i in range(save_states):
 		last_states.append([[]])
-		placed_animals.append(Animal.AnimalType.NONE)
 	#Here we iterated over the grid and fill it
 	for x in range(grid_size.x):
 		grid.append([])
@@ -230,7 +234,7 @@ func update_grid(pos, data):
 					grid[x + position.x][y - position.y] = ENTITY_TYPES.BOTTOM
 					
 			#this seems to be the only way to keep track of the placed animals
-			placed_animals[state % save_states] = Animal.AnimalType.DEER
+			placed_animals.append(Animal.AnimalType.DEER)
 			SingletonPlayer.add_to_animal_inventory(Animal.AnimalType.DEER, -1)
 		"SNAKE":
 			#Snake works just like Deer
@@ -258,7 +262,7 @@ func update_grid(pos, data):
 					grid[x + position.x][y - position.y] = ENTITY_TYPES.BOTTOM
 			
 			#this seems to be the only way to keep track of the placed animals
-			placed_animals[state % save_states] = Animal.AnimalType.SNAKE
+			placed_animals.append(Animal.AnimalType.SNAKE)
 			SingletonPlayer.add_to_animal_inventory(Animal.AnimalType.SNAKE, -1)
 		"SPIDER":
 			#Spider is the easiest, nothing much happens here
@@ -270,7 +274,7 @@ func update_grid(pos, data):
 					grid[x + position.x][y - position.y] = ENTITY_TYPES.ALLOWED
 					
 			#this seems to be the only way to keep track of the placed animals
-			placed_animals[state % save_states] = Animal.AnimalType.SPIDER
+			placed_animals.append(Animal.AnimalType.SPIDER)
 			SingletonPlayer.add_to_animal_inventory(Animal.AnimalType.SPIDER, -1)
 		"SQUIRREL":
 			#Squirrel like the other animals
@@ -291,7 +295,7 @@ func update_grid(pos, data):
 					grid[x + position.x][y - position.y] = ENTITY_TYPES.BOTTOM
 			
 			#this seems to be the only way to keep track of the placed animals
-			placed_animals[state % save_states] = Animal.AnimalType.SQUIRREL
+			placed_animals.append(Animal.AnimalType.SQUIRREL)
 			SingletonPlayer.add_to_animal_inventory(Animal.AnimalType.SQUIRREL, -1)
 			
 	#This allows us to track the previous states and return to them
@@ -329,7 +333,6 @@ func make_invisible():
 	Global.something_is_being_dragged = false
 
 func reset_grid():
-	print("reset")
 	#To reset the grid we simple return it to the state we saved in the beginning
 	if Global.drag_mode:
 		#reset the inventory to the original amount of animals
@@ -343,10 +346,11 @@ func reset_grid():
 		last_states = []
 		for i in range(save_states):
 			last_states.append([[]])
+			
+		placed_animals.clear()
 		state = 0
 
 func last_state():
-	print("last_state")
 	#To return to the previous state of the grid we have to make sure that such a state exists
 	#Here we check if somebody tried to reset the start, this is not allowed
 	if Global.drag_mode:
@@ -367,8 +371,7 @@ func last_state():
 			last_states[(state + 1) % save_states] = [[]]
 			color_grid()
 			
-			SingletonPlayer.add_to_animal_inventory(placed_animals[state % save_states])
-			placed_animals[state % save_states] = Animal.AnimalType.NONE
+			SingletonPlayer.add_to_animal_inventory(placed_animals.pop_back())
 			update_inventory()
 			
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -60,11 +60,6 @@ signal current_grid(current_grid)
 enum ENTITY_TYPES {GROUND, WATER, AIR, ANIMAL, FORBIDDEN, ALLOWED, SIDE, BOTTOM, SHALLOW}
 
 func _ready():
-	
-	SingletonPlayer.add_to_animal_inventory(Animal.AnimalType.DEER, 2)
-	SingletonPlayer.add_to_animal_inventory(Animal.AnimalType.SNAKE, 2)
-	
-	start_animals = SingletonPlayer.get_animal_inventory().duplicate(true)
 	#update the ui
 	update_inventory()
 	

--- a/Arch-enemies/bridges/script/grid_drag.gd
+++ b/Arch-enemies/bridges/script/grid_drag.gd
@@ -39,7 +39,6 @@ func _get_drag_data(at_position):
 		var sprite = texture
 		#2) And the Tooltip, which identifies the animal
 		var animal = tooltip_text 
-
 		#due to we use the tooltip we need to check if the string is valid... this is not secure for typos!
 		if animal != "" and SingletonPlayer.get_animal_inventory()[Animal.string_to_type(animal)] <= 0:
 			return
@@ -48,7 +47,7 @@ func _get_drag_data(at_position):
 		var c = Control.new()
 		c.add_child(preview)
 		
-		if(sprite != null):
+		if(sprite != null):			
 			#If we are not trying to drag the TRect that represent the grid we create the preview
 			preview.expand = true
 			preview.texture = sprite

--- a/Arch-enemies/bridges/script/grid_drag.gd
+++ b/Arch-enemies/bridges/script/grid_drag.gd
@@ -39,6 +39,10 @@ func _get_drag_data(at_position):
 		var sprite = texture
 		#2) And the Tooltip, which identifies the animal
 		var animal = tooltip_text 
+
+		#due to we use the tooltip we need to check if the string is valid... this is not secure for typos!
+		if animal != "" and SingletonPlayer.get_animal_inventory()[Animal.string_to_type(animal)] <= 0:
+			return
 		
 		#This adds a control node that allows us to fix the position of the preview
 		var c = Control.new()
@@ -64,10 +68,10 @@ func _get_drag_data(at_position):
 					preview.set_size(Vector2(10, 20))
 					preview.tooltip_text = "SQUIRREL"
 		
-		c.set_global_position(Vector2i(0, 0))
-		
-		add_child(c)
-		
+			c.set_global_position(Vector2i(0, 0))
+			#this must be in the if case, otherwise we instantiate the drag_grid
+			add_child(c)
+
 		data["sprite"] = sprite
 		data["animal"] = animal
 		return data

--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -90,10 +90,11 @@ func use_item(requested_item:Item.ItemType):
 # --- / 
 # -- / animal inventory
 
-func add_to_animal_inventory(new_animal:Animal.AnimalType): 
+func add_to_animal_inventory(new_animal:Animal.AnimalType, quantity:int = 1): 
+	print(quantity)
 	if new_animal != Animal.AnimalType.NONE:
 		# valid entry given 
-		animal_inventory[new_animal] += 1
+		animal_inventory[new_animal] += quantity
 		#selected_animal.increase_amount
 		updated_animal_inventory.emit(animal_inventory)
 

--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -91,7 +91,6 @@ func use_item(requested_item:Item.ItemType):
 # -- / animal inventory
 
 func add_to_animal_inventory(new_animal:Animal.AnimalType, quantity:int = 1): 
-	print(quantity)
 	if new_animal != Animal.AnimalType.NONE:
 		# valid entry given 
 		animal_inventory[new_animal] += quantity


### PR DESCRIPTION
## Motivation
closes #172 

Implements a basic inventory behavior with animals for the bridge building linked to the global inventory provided by @ScatteredDrifter.
Also found a bug which caused the grid.tscn Node getting uneccesarry duplicated.

## What was changed/added
Added new variables to the grid. for the revert option. And a new condition in the grid_drag.gd checking if we have enough animals

## Testing



https://github.com/mango-gremlin/arch-enemies/assets/59502349/5c718afe-ad1f-4e25-9993-8e57e747d469


If you wan't to test this locally I suggest adding this code into the `_ready()` function in grid.gd

```
SingletonPlayer.add_to_animal_inventory(Animal.AnimalType.DEER, 2)
SingletonPlayer.add_to_animal_inventory(Animal.AnimalType.SNAKE, 2)
	
start_animals = SingletonPlayer.get_animal_inventory().duplicate(true)
```

## Additional Information
We might need to be careful if we exit the bridge building, due to currently we do not reset the animal inventory count!
