### PR TITLE
bridges | Added the dynamic grid

### DIFF
--- a/Arch-enemies/bridges/scenes/Grid.tscn
+++ b/Arch-enemies/bridges/scenes/Grid.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=33 format=3 uid="uid://bl1jporj7hosu"]
+[gd_scene load_steps=34 format=3 uid="uid://bl1jporj7hosu"]
 
 [ext_resource type="Texture2D" uid="uid://d0o2q6fijmd1" path="res://assets/art/tilesets/bridge_tileset/bridge_background_color.png" id="1_uowbf"]
+[ext_resource type="Script" path="res://bridges/script/Camera.gd" id="1_vkapa"]
 [ext_resource type="Script" path="res://bridges/script/grid.gd" id="1_xtvvi"]
 [ext_resource type="Texture2D" uid="uid://dgoo8sdw24hp0" path="res://assets/art/tilesets/bridge_tileset/bridge_air_tiles.png" id="2_4xri4"]
 [ext_resource type="Script" path="res://bridges/script/grid_visualizer.gd" id="2_d8ovy"]
@@ -774,6 +775,7 @@ sources/6 = SubResource("TileSetAtlasSource_meq0p")
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(192, 108)
 zoom = Vector2(3, 3)
+script = ExtResource("1_vkapa")
 
 [node name="Grid" type="TileMap" parent="."]
 tile_set = SubResource("TileSet_ne4ig")
@@ -884,11 +886,13 @@ position = Vector2(340, 95)
 
 [node name="parallax_background" parent="." instance=ExtResource("18_uekha")]
 
+[connection signal="send_zoom" from="Camera2D" to="Grid" method="_on_camera_2d_send_zoom"]
 [connection signal="current_grid" from="Grid" to="Grid/Control/Drag_Grid" method="_on_grid_current_grid"]
 [connection signal="current_grid" from="Grid" to="Grid/Control/Animal_Inventory/Deer_Item" method="_on_grid_current_grid"]
 [connection signal="current_grid" from="Grid" to="Grid/Control/Animal_Inventory/Snake_Item" method="_on_grid_current_grid"]
 [connection signal="current_grid" from="Grid" to="Grid/Control/Animal_Inventory/Spider_Item" method="_on_grid_current_grid"]
 [connection signal="current_grid" from="Grid" to="Grid/Control/Animal_Inventory/Squirrel_Item" method="_on_grid_current_grid"]
+[connection signal="get_zoom" from="Grid" to="Camera2D" method="_on_grid_get_zoom"]
 [connection signal="is_dragging" from="Grid/Control/Drag_Grid" to="Grid" method="_on_drag_grid_is_dragging"]
 [connection signal="need_grid" from="Grid/Control/Drag_Grid" to="Grid" method="_on_drag_grid_need_grid"]
 [connection signal="update_grid" from="Grid/Control/Drag_Grid" to="Grid" method="_on_drag_grid_update_grid"]

--- a/Arch-enemies/bridges/script/Camera.gd
+++ b/Arch-enemies/bridges/script/Camera.gd
@@ -1,0 +1,18 @@
+extends Camera2D
+signal send_zoom(zoom)
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+
+func _on_grid_get_zoom():
+	#Essentially we just use this script to dynamically send the zoom
+	#We are using a script of it's own in case we want camera movements or other similar things
+	send_zoom.emit(zoom)

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -10,8 +10,8 @@ var tile_size = tile_set.tile_size
 #Base asumption is no zoom, but it essentially does not matter for our purposes
 var x_zoom = 1
 var y_zoom = 1
-@export var x_size = int(DisplayServer.window_get_size().x / int(10 * x_zoom))
-@export var y_size = int(DisplayServer.window_get_size().y / int(10 * y_zoom))
+@export var x_size = int(DisplayServer.window_get_size().x / int(10 * x_zoom)) + 1
+@export var y_size = int(DisplayServer.window_get_size().y / int(10 * y_zoom)) + 1
 @export var square_size = 10
 
 
@@ -428,6 +428,7 @@ func _on_last_state_pressed():
 func _on_camera_2d_send_zoom(zoom):
 	#We adjust and recalculate the zoom if necessary
 	x_zoom = zoom.x
-	y_zoom  = zoom.y
-	x_size = int(DisplayServer.window_get_size().x / int(10 * x_zoom))
-	y_size = int(DisplayServer.window_get_size().y / int(10 * y_zoom))
+	y_zoom = zoom.y
+	x_size = int(DisplayServer.window_get_size().x / int(10 * x_zoom)) + 1
+	y_size = int(DisplayServer.window_get_size().y / int(10 * y_zoom)) + 1
+	grid_size = Vector2(x_size, y_size)

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -6,9 +6,14 @@ extends TileMap
 var tile_size = tile_set.tile_size
 
 #The Dimensions of the Grid
-@export var x_size = 39
-@export var y_size = 22
+#We add some variables to adjust to the zoom
+#Base asumption is no zoom, but it essentially does not matter for our purposes
+var x_zoom = 1
+var y_zoom = 1
+@export var x_size = int(DisplayServer.window_get_size().x / int(10 * x_zoom))
+@export var y_size = int(DisplayServer.window_get_size().y / int(10 * y_zoom))
 @export var square_size = 10
+
 
 #And finally some values we need later
 var grid_size = Vector2(x_size, y_size)
@@ -47,6 +52,7 @@ var water_squares = []
 
 #This is the signal we use to transfer the current grid to child nodes
 signal current_grid(current_grid)
+signal get_zoom()
 
 #These are the different kind of object we can have in grid cells
 enum ENTITY_TYPES {GROUND, WATER, AIR, ANIMAL, FORBIDDEN, ALLOWED, SIDE, BOTTOM, SHALLOW}
@@ -55,6 +61,8 @@ func _ready():
 	#We save the previous states of the grid in an array, this array is initalized here
 	for i in range(save_states):
 		last_states.append([[]])
+	#We have to adjust the window size if zoomed in
+	get_zoom.emit()
 	#Here we iterated over the grid and fill it
 	for x in range(grid_size.x):
 		grid.append([])
@@ -416,3 +424,10 @@ func _on_reset_pressed():
 
 func _on_last_state_pressed():
 	last_state()
+
+func _on_camera_2d_send_zoom(zoom):
+	#We adjust and recalculate the zoom if necessary
+	x_zoom = zoom.x
+	y_zoom  = zoom.y
+	x_size = int(DisplayServer.window_get_size().x / int(10 * x_zoom))
+	y_size = int(DisplayServer.window_get_size().y / int(10 * y_zoom))


### PR DESCRIPTION
## Motivation
closes #248

To implement additional levels it would be good if the grid adjusts automatically so we can just repeatedly implement the same scene.

## What was changed/added
Camera has it's own script now. It just sends it current zoom. Since camera is often used for many things giving it it's own script is future proofing. On ready the grid.gd now signals to get the zoom and with that adjusts the grid size.

## Testing
![everything is peaceful](https://github.com/mango-gremlin/arch-enemies/assets/65815628/9bd20409-773e-4292-94b0-eb70841f97b6)

The grid looks the same even though the sizes are not hard coded.

## Additional Information
Note that if you adjust the zoom you have to adjust the camera position, but this is trivially true.