### PR TITLE
overworld | improve save \ loading information ( to/from singleton)

### DIFF
--- a/Arch-enemies/overworld/entities/Player/ZoomCamera.gd
+++ b/Arch-enemies/overworld/entities/Player/ZoomCamera.gd
@@ -12,7 +12,8 @@ var current_zoom = 1
 func _set_current_zoom(value: float, store: bool = false):
 	var tween = create_tween()
 	current_zoom = clamp(value, MIN_ZOOM, MAX_ZOOM)
-	
+	# save updated zoom in singleton
+	SingletonPlayer.set_player_zoom(current_zoom)
 	if store:
 		if player_object != null:
 			player_object.savePlayer()

--- a/Arch-enemies/overworld/overworld.gd
+++ b/Arch-enemies/overworld/overworld.gd
@@ -1,18 +1,16 @@
 extends Node
 
 # for ysort to work, player needs to be child of tilemap, so Player has a different position
-@onready var player_object = $world/TileMap/Player
-@onready var Savemanager = Savemanagement.new(player_object)
+#@onready var player_object = $world/TileMap/Player
+#@onready var Savemanager = Savemanagement.new()
 
 
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	Savemanager.load_config()
+	SingletonPlayer.signal_inventory_update_ui()
+	#Savemanager.load_config()
 	#player_object.maingame = self
-	
-	# TODO add input to set 
-	Savemanager.select_profile("default")
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -22,5 +20,5 @@ func _process(delta):
 
 # function, called if player saves game
 func _on_player_saved_player():
-	Savemanager.save_config()
-	#pass # Replace with function body.
+	#Savemanager.save_config()
+	pass # Replace with function body.

--- a/Arch-enemies/overworld/scripts/save_management.gd
+++ b/Arch-enemies/overworld/scripts/save_management.gd
@@ -7,18 +7,19 @@ var current_profile = "default"
 var profiles:Array = ["default"]
 
 # denotes reference to player object
-var player_object
-var camera_object
+#var player_object
+#var camera_object
 
 var state_path = "user://arch-enemies.json"
 
 # default constructor
 # TODO #89
-func _init(playerObject):
+func _init():
+	pass
 	# set player object accordingly 
 	
-	player_object = playerObject
-	camera_object = player_object.find_child("Camera2D")
+	#player_object = playerObject
+	#camera_object = player_object.find_child("Camera2D")
 	
 
 # See https://docs.godotengine.org/en/stable/tutorials/io/saving_games.html
@@ -50,7 +51,8 @@ func load_config():
 			var position_x = node_data["pos_x"]
 			var position_y = node_data["pos_y"]
 			
-			player_object.position = Vector2(position_x, position_y)
+			#player_object.position = Vector2(position_x, position_y)
+			SingletonPlayer.player_coordinate = Vector2(position_x, position_y)
 			
 			var new_inventory: Dictionary = generate_inventory(node_data["inventory"])
 			SingletonPlayer.set_item_inventory(new_inventory)
@@ -60,7 +62,9 @@ func load_config():
 			
 			
 			
-			camera_object._set_current_zoom(node_data["zoom"])
+			#camera_object._set_current_zoom(node_data["zoom"])
+			var zoom:int = node_data["zoom"]
+			SingletonPlayer.zoomlevel = zoom
 			
 		if node_data["name"] == "Profiles":
 			profiles = node_data["profiles"]
@@ -111,7 +115,7 @@ func save_config():
 	var save = FileAccess.open(state_path, FileAccess.WRITE)
 
 	# Storing THE CURRENT player data
-	var player_state = player_object.save_state()
+	var player_state = SingletonPlayer.save_player_state()
 	player_state["profile"] = current_profile
 	
 	print("Storing player state \"", player_state, " ...") 

--- a/Arch-enemies/overworld/ui/menu/menu/pause_menu.gd
+++ b/Arch-enemies/overworld/ui/menu/menu/pause_menu.gd
@@ -19,4 +19,5 @@ func _on_overworld_pressed():
 
 func _on_exit_pressed():
 	# exit game
+	SingletonPlayer.save_game()
 	get_tree().quit()


### PR DESCRIPTION

## Motivation
resolves #267 
but primarily adds a better flow of data to **load** information when **entering the overworld**. 

**Now**:
- we only save the state to **file** when the game is closed 
- we only load from **file** when the game is started ( and the singleton is instantiated

- everything related to the overworld draws its information from the **singleton** now --> Player, Camera-Zoom, Overworld-Ui ...
- those objects also **update the singleton** whenever a value changed ( like zoom for example )
- added functionality to **save coordinates** when entering a bridge-scene
- added functionality to load coordinates, zoom and inventory from **singleton** when entering the overworld

## What was changed/added
All of the above: 
-> Those changes spread across many files in our overworld directory. 

1. added a method to send a signal to **overworld-ui** helping to load the inventory from the singleton into the overworld-ui --> and then displaying it correctly upon entering a scene
2. moved `saved_state()` from save_management to singleton and renamed it to `save_player_state()`. All its content is now drawn from the singleton itself 
3. added method `save_game()` to allow saving the whole game by calling this from singleton --> could also be done with reference to the savemanager but this provides **an interface** that could do additional tasks too. ( show a tween to close the game or whatsoever ... ) 

## Testing
**You may have to delete your save-file**  --> see the wiki to find out how :)  
Visually not much changed but you should now be able to: 
- enter the pause menu, close it and be in the same position as before ( without saving to the file! ) 
- enter the bridge-game, solve it ( no exit button yet! ) and be in the same position as before
- the zoom should restore automatically too! 
