### PR TITLE
bridges | added pause menu to new bridge level

### DIFF
--- a/Arch-enemies/bridges/scenes/Grid.tscn
+++ b/Arch-enemies/bridges/scenes/Grid.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=34 format=3 uid="uid://bl1jporj7hosu"]
+[gd_scene load_steps=35 format=3 uid="uid://cjsjvpeuuqot"]
 
 [ext_resource type="Texture2D" uid="uid://d0o2q6fijmd1" path="res://assets/art/tilesets/bridge_tileset/bridge_background_color.png" id="1_uowbf"]
 [ext_resource type="Script" path="res://bridges/script/Camera.gd" id="1_vkapa"]
@@ -20,6 +20,7 @@
 [ext_resource type="PackedScene" uid="uid://cxj1q08s3i7i8" path="res://bridges/scenes/goal_menu.tscn" id="15_sf441"]
 [ext_resource type="PackedScene" uid="uid://dfnsuounqjr4c" path="res://bridges/scenes/goal.tscn" id="16_f3lv2"]
 [ext_resource type="PackedScene" uid="uid://dynxnwixd1bke" path="res://bridges/scenes/parallax_background.tscn" id="18_uekha"]
+[ext_resource type="PackedScene" uid="uid://cv4r3ql0yg1la" path="res://overworld/ui/menu/menu/pause_menu.tscn" id="20_cqwsn"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_gxf1m"]
 texture = ExtResource("1_uowbf")
@@ -883,6 +884,20 @@ size_flags_vertical = 4
 
 [node name="goal" parent="Grid" instance=ExtResource("16_f3lv2")]
 position = Vector2(340, 95)
+
+[node name="pause_menu" parent="Grid" instance=ExtResource("20_cqwsn")]
+visible = false
+anchors_preset = -1
+anchor_left = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = 200.0
+offset_top = 100.0
+offset_right = 200.0
+offset_bottom = 100.0
+scale = Vector2(0.5, 0.5)
+size_flags_horizontal = 4
+metadata/_edit_use_anchors_ = true
 
 [node name="parallax_background" parent="." instance=ExtResource("18_uekha")]
 

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -372,6 +372,11 @@ func tile_update(pos, current, next):
 func _process(delta):
 	if(Global.currently_dragging and Input.is_action_just_released("click")):
 		make_invisible()
+		
+	# pressing "esc" opens the pause-menu
+	if Input.is_action_just_pressed("open_menu"):
+		var pause_menu = get_parent().find_child("pause_menu")
+		pause_menu.visible = not pause_menu.visible
 
 #Down here we handle all the signal. There will be many, but most of them don't do much.
 func _on_drag_grid_need_grid():


### PR DESCRIPTION
## Motivation
closes #174 

The pause_menu wasn't accessible in the new bridge level, so it needed to be added.

## What was changed/added
The pause_menu isn't accessed by changing the scene like before, but by having a pause_menu node inside of the scene.
Opening it by pressing "esc" just changes the visibility of the node, so it can be opened and closed.

## Testing

https://github.com/mango-gremlin/arch-enemies/assets/116217918/7ab09900-117f-4232-b3f7-9ba650c068e3

You can open and close the pause_menu by pressing "esc". 
Interestingly enough it looks different when it actually changes the scene like in the overworld eventhough it's the same menu.

## Additional Information
You can still move the animals when the pause_menu is pressed. This is also the case in the goal_menu, so if we want to change this, both should be edited.

Both of the menus should also be updated in ther visual apperance by the UI team. Trying to center the menus is kind of frustrating since the bridge scene doesn't seem to actually fill the screen outline of godot, so the automatic centering options of godot also don't work.