### PR TITLE
overworld | bridge remove empty inventory to overwrite state saved in singleton

### DIFF
--- a/Arch-enemies/overworld/scripts/save_management.gd
+++ b/Arch-enemies/overworld/scripts/save_management.gd
@@ -56,8 +56,10 @@ func load_config():
 			
 			var new_inventory: Dictionary = generate_inventory(node_data["inventory"])
 			SingletonPlayer.set_item_inventory(new_inventory)
-			var animal_inventory:Dictionary = Animal.init_animal_inventory()
-			SingletonPlayer.set_animal_inventory(animal_inventory)
+			
+			# FIXME only uncomment once we have implemented saving the animal inventory too
+			#var animal_inventory:Dictionary = Animal.init_animal_inventory()
+			#SingletonPlayer.set_animal_inventory(animal_inventory)
 			#player_object.set_inventory(new_inventory)
 			
 			


### PR DESCRIPTION

## Motivation
merging the bridge inventory and also updating the save management --> while also setting it with default values 
the **debugging function to set an arbitrary animal-inventory** was overwritten by the save management that loads a state upon instantiation. 

This is now fixed, by removing the empty inventory from the save management. 
Furher I added a flag that indicates where to set the inventory once it can be saved / loaded accordingly.

## Testing
Tested by @aylinfi  live