### PR TITLE
Extended squirrel logic for shallow

### DIFF
--- a/Arch-enemies/bridges/script/grid_drag.gd
+++ b/Arch-enemies/bridges/script/grid_drag.gd
@@ -184,10 +184,10 @@ func is_squirrel_allowed(pos):
 			is_allowed = true
 		#Is there space for the animal?
 		if(pos_Type == ENTITY_TYPES.FORBIDDEN 
-		or pos_Type == ENTITY_TYPES.GROUND 
-		or pos_Type == ENTITY_TYPES.WATER 
-		or pos_Type == ENTITY_TYPES.ANIMAL 
-		or pos_Type == ENTITY_TYPES.SHALLOW):
+			or pos_Type == ENTITY_TYPES.GROUND 
+			or pos_Type == ENTITY_TYPES.WATER 
+			or pos_Type == ENTITY_TYPES.ANIMAL 
+			or pos_Type == ENTITY_TYPES.SHALLOW):
 			is_free = false
 	return is_allowed and is_free
 	

--- a/Arch-enemies/bridges/script/grid_drag.gd
+++ b/Arch-enemies/bridges/script/grid_drag.gd
@@ -182,9 +182,12 @@ func is_squirrel_allowed(pos):
 		#Is there something to attach the animal to?
 		if(pos_Type == ENTITY_TYPES.ALLOWED or pos_Type == ENTITY_TYPES.SIDE):
 			is_allowed = true
-		#Is there space for the animal?	
-		if(pos_Type == ENTITY_TYPES.FORBIDDEN or pos_Type == ENTITY_TYPES.GROUND or
-			pos_Type == ENTITY_TYPES.WATER or pos_Type == ENTITY_TYPES.ANIMAL):
+		#Is there space for the animal?
+		if(pos_Type == ENTITY_TYPES.FORBIDDEN 
+		or pos_Type == ENTITY_TYPES.GROUND 
+		or pos_Type == ENTITY_TYPES.WATER 
+		or pos_Type == ENTITY_TYPES.ANIMAL 
+		or pos_Type == ENTITY_TYPES.SHALLOW):
 			is_free = false
 	return is_allowed and is_free
 	


### PR DESCRIPTION
## Motivation
closes #263

## What was changed/added
Updated the logic for squirrel, so it accounts for SHALLOW, which means setting the `is_free` to false when any part of the squirrel would end up in shallows. 

## Testing
As you can see, the illegal placement as described in #263 is no longer possible.

https://github.com/mango-gremlin/arch-enemies/assets/104799849/3f726aed-3f50-44e1-9228-381725aa9a5e

As you can see, the squirrel still should work elsewhere

https://github.com/mango-gremlin/arch-enemies/assets/104799849/416c3cc2-439d-4c9f-a75a-8bebd9e68dd0
