### PR TITLE
bridges | update singleton after level was solved

### DIFF
--- a/Arch-enemies/bridges/scenes/Grid.tscn
+++ b/Arch-enemies/bridges/scenes/Grid.tscn
@@ -959,3 +959,4 @@ text = "0"
 [connection signal="toggled" from="Grid/Control/Drag_or_Fox" to="Grid/Control/Drag_or_Fox" method="_on_toggled"]
 [connection signal="pressed" from="Grid/Control/Reset" to="Grid" method="_on_reset_pressed"]
 [connection signal="pressed" from="Grid/Control/Last_State" to="Grid" method="_on_last_state_pressed"]
+[connection signal="level_solved" from="Grid/goal_menu" to="Grid" method="_on_goal_menu_level_solved"]

--- a/Arch-enemies/bridges/script/goal_menu.gd
+++ b/Arch-enemies/bridges/script/goal_menu.gd
@@ -12,16 +12,8 @@ func _on_retry_button_pressed():
 func _on_continue_button_pressed():
 	# Update global inventory
 	level_solved.emit()
-	# Add bridge edge to Singleton, I used the values from Singleton.bridge_level_scenes
-	#print("Build bridges for finish: ", SingletonPlayer.bridges_built)
-	SingletonPlayer.add_bridge_connection(get_bridge_edge())
-	#print("Build bridges after finish: ", SingletonPlayer.bridges_built)
+	# Add bridge edge to Singleton
+	var current_edge = SingletonPlayer.get_current_bridge_edge()
+	SingletonPlayer.add_bridge_connection(current_edge)
+	SingletonPlayer.set_current_bridge_edge(null)
 	get_tree().change_scene_to_file("res://overworld/main_scene_overworld.tscn")
-
-func get_bridge_edge():
-	var levels = SingletonPlayer.bridge_level_scenes
-	for level in levels:
-		var path = levels[level]
-		if path == get_tree().current_scene.scene_file_path:
-			return levels.find_key(path)
-		# TODO: create new entry?

--- a/Arch-enemies/bridges/script/goal_menu.gd
+++ b/Arch-enemies/bridges/script/goal_menu.gd
@@ -13,11 +13,10 @@ func _on_continue_button_pressed():
 	# Update global inventory
 	level_solved.emit()
 	# Add bridge edge to Singleton, I used the values from Singleton.bridge_level_scenes
-	print("Build bridges for finish: ", SingletonPlayer.bridges_built)
+	#print("Build bridges for finish: ", SingletonPlayer.bridges_built)
 	SingletonPlayer.add_bridge_connection(get_bridge_edge())
-	print("Build bridges after finish: ", SingletonPlayer.bridges_built)
+	#print("Build bridges after finish: ", SingletonPlayer.bridges_built)
 	get_tree().change_scene_to_file("res://overworld/main_scene_overworld.tscn")
-	print("lets go to the overworld now")
 
 func get_bridge_edge():
 	var levels = SingletonPlayer.bridge_level_scenes

--- a/Arch-enemies/bridges/script/goal_menu.gd
+++ b/Arch-enemies/bridges/script/goal_menu.gd
@@ -15,5 +15,5 @@ func _on_continue_button_pressed():
 	# Add bridge edge to Singleton
 	var current_edge = SingletonPlayer.get_current_bridge_edge()
 	SingletonPlayer.add_bridge_connection(current_edge)
-	SingletonPlayer.set_current_bridge_edge(null)
+	#SingletonPlayer.set_current_bridge_edge(null)
 	get_tree().change_scene_to_file("res://overworld/main_scene_overworld.tscn")

--- a/Arch-enemies/bridges/script/goal_menu.gd
+++ b/Arch-enemies/bridges/script/goal_menu.gd
@@ -1,5 +1,7 @@
 extends Control
 
+signal level_solved
+
 func _on_retry_button_pressed():
 	get_parent().get_node("Player").reset_player()
 	Global.drag_mode = true
@@ -8,6 +10,19 @@ func _on_retry_button_pressed():
 
 
 func _on_continue_button_pressed():
-	# TODO return to overworld scene
+	# Update global inventory
+	level_solved.emit()
+	# Add bridge edge to Singleton, I used the values from Singleton.bridge_level_scenes
+	print("Build bridges for finish: ", SingletonPlayer.bridges_built)
+	SingletonPlayer.add_bridge_connection(get_bridge_edge())
+	print("Build bridges after finish: ", SingletonPlayer.bridges_built)
 	get_tree().change_scene_to_file("res://overworld/main_scene_overworld.tscn")
 	print("lets go to the overworld now")
+
+func get_bridge_edge():
+	var levels = SingletonPlayer.bridge_level_scenes
+	for level in levels:
+		var path = levels[level]
+		if path == get_tree().current_scene.scene_file_path:
+			return levels.find_key(path)
+		# TODO: create new entry?

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -506,3 +506,7 @@ func _on_camera_2d_send_zoom(zoom):
 	x_size = int(DisplayServer.window_get_size().x / int(10 * x_zoom)) + 1
 	y_size = int(DisplayServer.window_get_size().y / int(10 * y_zoom)) + 1
 	grid_size = Vector2(x_size, y_size)
+
+
+func _on_goal_menu_level_solved():
+	set_global_animal_inventory(start_animals)

--- a/Arch-enemies/bridges/script/grid_drag.gd
+++ b/Arch-enemies/bridges/script/grid_drag.gd
@@ -22,7 +22,6 @@ signal is_dragging
 func _ready():
 	# take animal inventory from parent-Grid tilemap
 	animal_inventory_reference = Grid_node_reference.start_animals
-	print("inv in grid drag")
 	
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/Arch-enemies/overworld/entities/Player/Player.gd
+++ b/Arch-enemies/overworld/entities/Player/Player.gd
@@ -209,6 +209,7 @@ func enter_bridge_scene(bridgeEdge:SingletonPlayer.BridgeEdge):
 			# found matching path 
 			var path_to_scene:String = updated_bridge_edge.path
 			#exit_overworld()
+			SingletonPlayer.set_current_bridge_edge(bridgeEdge)
 			get_tree().change_scene_to_file(path_to_scene)
 
 # ---- 

--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -163,6 +163,17 @@ var islands_reachable:Array[bool]
 	BridgeEdge.new(0,2): "res://bridges/scenes/Grid.tscn",
 }
 
+# used for the (possibly) active bridge level to find out its own bridge egde
+@onready var current_bridge_edge
+
+# sets the current bridge edge while the player is entering a bridge level
+func set_current_bridge_edge(new_edge:BridgeEdge):
+	current_bridge_edge = new_edge
+
+# retrieve the bridge edge of the currently active bridge level
+func get_current_bridge_edge() -> BridgeEdge:
+	return current_bridge_edge
+
 # queries dictionary of available bridge-level for requested level
 # returns modified bridge-edge with path set if found 
 # returns unchanged bridge-edge otherwise

--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -164,7 +164,7 @@ var islands_reachable:Array[bool]
 }
 
 # used for the (possibly) active bridge level to find out its own bridge egde
-@onready var current_bridge_edge
+@onready var current_bridge_edge:BridgeEdge
 
 # sets the current bridge edge while the player is entering a bridge level
 func set_current_bridge_edge(new_edge:BridgeEdge):


### PR DESCRIPTION
## Motivation
closes #250

After the level is finished (which happens when entering the _goal area_), we want to update the global inventory and bridge connection list.

## What was changed/added
When clicking the "Continue" button in the goal menu, the SingletonPlayer inventory is updated and the necessary bridge-edges are added.
Because while returning to the overworld we will not change the level, nothing else has to be changed.

## Testing
https://github.com/mango-gremlin/arch-enemies/assets/57258671/d793841a-b36c-4e44-8de9-7f631c33e4b4
Through print statements before and after you can see that the bridge edge was added correctly.
![grafik](https://github.com/mango-gremlin/arch-enemies/assets/57258671/9df6d027-9f2a-46af-ad65-63f96cdb0832)


## Additional Information
For this implementation to work the current level must exist in SingletonPlayer.bridge_level_scenes. If there is a better solution to find out which BridgeEdge we are using in the current level, let me know.
