### PR TITLE
Bug | leaving overworld updates item inventory instead of animal inventory 

### DIFF
--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -438,7 +438,7 @@ func restore_animal_from_placed_animals(placed_animals:Dictionary):
 # takes local inventory, duplicates it and replace 
 # singleton animal_inventory with it
 func set_global_animal_inventory(animal_inventory:Dictionary):
-	SingletonPlayer.set_item_inventory(animal_inventory.duplicate(true))
+	SingletonPlayer.set_animal_inventory(animal_inventory.duplicate(true))
 
 #updates the ui-counters for the inventory
 func update_inventory():
@@ -509,4 +509,5 @@ func _on_camera_2d_send_zoom(zoom):
 
 
 func _on_goal_menu_level_solved():
+	print("updating inventory of overworld")
 	set_global_animal_inventory(start_animals)

--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -126,9 +126,10 @@ func add_to_animal_inventory(new_animal:Animal.AnimalType, quantity:int = 1):
 # used for debugging only
 func set_test_animal_inventory() -> Dictionary:
 	var inventory:Dictionary = Animal.init_animal_inventory()
-	inventory[Animal.AnimalType.DEER] = 1
-	inventory[Animal.AnimalType.SNAKE] = 1
-	inventory[Animal.AnimalType.SQUIRREL] = 1
+	inventory[Animal.AnimalType.DEER] = 99
+	inventory[Animal.AnimalType.SPIDER] = 99
+	inventory[Animal.AnimalType.SNAKE] = 99
+	inventory[Animal.AnimalType.SQUIRREL] = 99
 	return inventory 
 
 


### PR DESCRIPTION
## Motivation 
I observed a bug that updates the wrong inventory upon entering the overworld after a level was solved. 
I have not seen it when reviewing the PR, my bad / sorry. 

Additionally I gave some _more reasonable_ values for the test inventory --> so that ones does not have to change it that often. This will likely collide with #278 

## What was changed/added
using the right method in "grid.gd" to update the animal_inventory instead of item_inventory.

## Testing
Well, solve the level and you should observe that the updated inventory should be displayed in the "ui".
