### PR TITLE
bridges | update menus for the new levels

### DIFF
--- a/Arch-enemies/bridges/scenes/0_TutorialLevel.tscn
+++ b/Arch-enemies/bridges/scenes/0_TutorialLevel.tscn
@@ -902,6 +902,10 @@ position = Vector2(320, 86)
 
 [node name="bridges_pause_menu" parent="Grid" instance=ExtResource("20_1ny00")]
 visible = false
+offset_left = 193.0
+offset_top = 108.0
+offset_right = 193.0
+offset_bottom = 108.0
 
 [node name="animal_inventory_counter" type="HBoxContainer" parent="Grid"]
 offset_top = 38.0

--- a/Arch-enemies/bridges/scenes/0_TutorialLevel.tscn
+++ b/Arch-enemies/bridges/scenes/0_TutorialLevel.tscn
@@ -894,6 +894,10 @@ scale = Vector2(1, 10)
 [node name="goal_menu" parent="Grid" instance=ExtResource("18_65aa1")]
 visible = false
 top_level = true
+offset_left = 192.0
+offset_top = 108.0
+offset_right = -221.568
+offset_bottom = -136.296
 size_flags_horizontal = 4
 size_flags_vertical = 4
 

--- a/Arch-enemies/bridges/scenes/1_FrogHazardLevel.tscn
+++ b/Arch-enemies/bridges/scenes/1_FrogHazardLevel.tscn
@@ -899,7 +899,7 @@ scale = Vector2(1, 10)
 visible = false
 top_level = true
 offset_right = 0.432007
-scale = Vector2(1.2, 0.92)
+scale = Vector2(1.2, 1.2)
 size_flags_horizontal = 4
 size_flags_vertical = 4
 
@@ -908,6 +908,10 @@ position = Vector2(431, 92)
 
 [node name="bridges_pause_menu" parent="Grid" instance=ExtResource("20_t104i")]
 visible = false
+offset_left = 250.0
+offset_top = 109.0
+offset_right = 250.0
+offset_bottom = 109.0
 
 [node name="animal_inventory_counter" type="HBoxContainer" parent="Grid"]
 offset_top = 38.0

--- a/Arch-enemies/bridges/scenes/1_FrogHazardLevel.tscn
+++ b/Arch-enemies/bridges/scenes/1_FrogHazardLevel.tscn
@@ -898,8 +898,10 @@ scale = Vector2(1, 10)
 [node name="goal_menu" parent="Grid" instance=ExtResource("18_ihjef")]
 visible = false
 top_level = true
-offset_right = 0.432007
-scale = Vector2(1.2, 1.2)
+offset_left = 250.0
+offset_top = 108.0
+offset_right = 250.432
+offset_bottom = -136.296
 size_flags_horizontal = 4
 size_flags_vertical = 4
 

--- a/Arch-enemies/bridges/scenes/2_FinalLevel.tscn
+++ b/Arch-enemies/bridges/scenes/2_FinalLevel.tscn
@@ -903,6 +903,11 @@ position = Vector2(340, 95)
 
 [node name="bridges_pause_menu" parent="Grid" instance=ExtResource("20_20jtq")]
 visible = false
+offset_left = 288.0
+offset_top = 161.0
+offset_right = 288.0
+offset_bottom = 161.0
+scale = Vector2(1.5, 1.5)
 
 [node name="animal_inventory_counter" type="HBoxContainer" parent="Grid"]
 offset_top = 38.0

--- a/Arch-enemies/bridges/scenes/2_FinalLevel.tscn
+++ b/Arch-enemies/bridges/scenes/2_FinalLevel.tscn
@@ -895,6 +895,11 @@ scale = Vector2(1, 10)
 [node name="goal_menu" parent="Grid" instance=ExtResource("18_co2ox")]
 visible = false
 top_level = true
+offset_left = 288.0
+offset_top = 161.0
+offset_right = -125.568
+offset_bottom = -83.296
+scale = Vector2(1.5, 1.5)
 size_flags_horizontal = 4
 size_flags_vertical = 4
 

--- a/Arch-enemies/bridges/scenes/bridges_pause_menu.tscn
+++ b/Arch-enemies/bridges/scenes/bridges_pause_menu.tscn
@@ -12,9 +12,26 @@ anchors_preset = 0
 script = ExtResource("1_ym7wh")
 metadata/_edit_use_anchors_ = true
 
+[node name="BackgroundCenterV7" type="Sprite2D" parent="."]
+modulate = Color(0.498039, 0.498039, 0.498039, 1)
+z_index = 1
+position = Vector2(235, -118)
+scale = Vector2(1.2, 1.2)
+texture = ExtResource("2_0a5ka")
+centered = false
+
 [node name="BackgroundCenterV4" type="Sprite2D" parent="."]
 modulate = Color(0.498039, 0.498039, 0.498039, 1)
 z_index = 1
+position = Vector2(-238, -118)
+scale = Vector2(1.2, 1.2)
+texture = ExtResource("2_0a5ka")
+centered = false
+
+[node name="BackgroundCenterV6" type="Sprite2D" parent="."]
+modulate = Color(0.498039, 0.498039, 0.498039, 1)
+z_index = 1
+position = Vector2(-473, -118)
 scale = Vector2(1.2, 1.2)
 texture = ExtResource("2_0a5ka")
 centered = false
@@ -22,23 +39,22 @@ centered = false
 [node name="BackgroundCenterV5" type="Sprite2D" parent="."]
 modulate = Color(0.498039, 0.498039, 0.498039, 1)
 z_index = 1
-position = Vector2(236, 0)
+position = Vector2(-2, -118)
 scale = Vector2(1.2, 1.2)
 texture = ExtResource("2_0a5ka")
 centered = false
 
 [node name="MenuContainer" type="Sprite2D" parent="."]
 z_index = 1
-position = Vector2(195, 112.5)
 scale = Vector2(2.25, 2.25)
 texture = ExtResource("3_x8j61")
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="."]
 layout_mode = 2
-offset_left = 159.0
-offset_top = 79.0
-offset_right = 231.0
-offset_bottom = 151.0
+offset_left = -36.0
+offset_top = -33.0
+offset_right = 36.0
+offset_bottom = 39.0
 
 [node name="Label" type="Label" parent="VBoxContainer2"]
 z_index = 1

--- a/Arch-enemies/bridges/scenes/goal_menu.tscn
+++ b/Arch-enemies/bridges/scenes/goal_menu.tscn
@@ -9,39 +9,55 @@
 layout_mode = 3
 anchor_right = 0.359
 anchor_bottom = 0.377
-offset_right = -24.568
-offset_bottom = -24.296
+offset_right = -413.568
+offset_bottom = -244.296
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_e6stn")
 
-[node name="MenuContainer" type="Sprite2D" parent="."]
+[node name="BackgroundCenterV7" type="Sprite2D" parent="."]
+modulate = Color(0.498039, 0.498039, 0.498039, 1)
 z_index = 2
-position = Vector2(193, 112.5)
-scale = Vector2(2, 2)
-texture = ExtResource("2_i1o17")
+position = Vector2(235, -118)
+scale = Vector2(1.2, 1.2)
+texture = ExtResource("5_upwcu")
+centered = false
 
 [node name="BackgroundCenterV4" type="Sprite2D" parent="."]
 modulate = Color(0.498039, 0.498039, 0.498039, 1)
-z_index = 1
+z_index = 2
+position = Vector2(-238, -118)
+scale = Vector2(1.2, 1.2)
+texture = ExtResource("5_upwcu")
+centered = false
+
+[node name="BackgroundCenterV6" type="Sprite2D" parent="."]
+modulate = Color(0.498039, 0.498039, 0.498039, 1)
+z_index = 2
+position = Vector2(-473, -118)
 scale = Vector2(1.2, 1.2)
 texture = ExtResource("5_upwcu")
 centered = false
 
 [node name="BackgroundCenterV5" type="Sprite2D" parent="."]
 modulate = Color(0.498039, 0.498039, 0.498039, 1)
-z_index = 1
-position = Vector2(236, 0)
+z_index = 2
+position = Vector2(-2, -118)
 scale = Vector2(1.2, 1.2)
 texture = ExtResource("5_upwcu")
 centered = false
 
+[node name="MenuContainer" type="Sprite2D" parent="."]
+z_index = 2
+scale = Vector2(2, 2)
+texture = ExtResource("2_i1o17")
+
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 0
-offset_left = 161.0
-offset_top = 79.0
-offset_right = 226.0
-offset_bottom = 144.0
+offset_left = -33.0
+offset_top = -32.0
+offset_right = 32.0
+offset_bottom = 33.0
 alignment = 1
 
 [node name="Label" type="Label" parent="VBoxContainer"]


### PR DESCRIPTION
## Motivation
closes #288

Updated menu design to adjust to different level sizes.

## What was changed/added
The pause and goal menu was extended to the sides to adjust for bigger grid sizes. Extensions up and down can be provided via scaling the pause menu when needed.
Everything was centred to origin to make things easier to place.

## Testing
The new goal menu (pause menu is changed the same way):
![grafik](https://github.com/mango-gremlin/arch-enemies/assets/57258671/0a372519-0099-4f11-947a-28b33ed02031)

https://github.com/mango-gremlin/arch-enemies/assets/57258671/652d0f51-945b-4065-aa9d-f272be902055
It still works for the bigger levels.


## Additional Information
As seen in the video, everything is kinda squished for the frog hazard level because the zoom is not the same for the x and y axis. It should be considered to change that, or find another way.
