### PR TITLE
overworld | hide item when it was taking | add states to save progress after scene change

### DIFF
--- a/Arch-enemies/overworld/entities/Player/Player.gd
+++ b/Arch-enemies/overworld/entities/Player/Player.gd
@@ -158,13 +158,9 @@ func execute_interaction():
 			enter_bridge_scene(bridge_edge)
 			
 		Interactable.InteractionType.ITEM: 
-			print("obtained item")
-			set_interactionLabel(interaction_data["text"])
 			var received_item:Item.ItemType = interaction_data["item"]
 			# adding to inventory 
 			SingletonPlayer.add_to_inventory(received_item)
-			# updating ui 
-			# adding to inventory! 
 		Interactable.InteractionType.NPC:
 			var npc_id:int = interaction_data["npc_id"]
 			print("interacting with npc")

--- a/Arch-enemies/overworld/entities/interaction_overworld/interactionspot.gd
+++ b/Arch-enemies/overworld/entities/interaction_overworld/interactionspot.gd
@@ -72,11 +72,9 @@ func interact_bridge() -> InteractionValue:
 func interact_item() -> InteractionValue: 
 # querying item to receive 
 	var received_item = parent_node.obtain_item()
-	var received_dialogue = parent_node.obtain_dialogue()
 	# construction interactionValue
 	var queried_values:Dictionary = {
 		"item": received_item, 
-		"text": received_dialogue,
 	}
 	var interaction_result:InteractionValue = InteractionValue.new(InteractionType.ITEM,queried_values)
 	return interaction_result

--- a/Arch-enemies/overworld/entities/interaction_overworld/item_interaction.gd
+++ b/Arch-enemies/overworld/entities/interaction_overworld/item_interaction.gd
@@ -17,31 +17,22 @@ var interaction_type: Interactable.InteractionType = Interactable.InteractionTyp
 # TODO convert to Issue on Github to track!
 @export var item_amount:int = 1
 @export var itemspot_id:int = 0
-
-# denotes item Object
-#var item_instance:Item
-
-# string denoting what is shown upon gathering the item 
-@export var item_dialogue_success: String
-@export var item_dialogue_failure: String
-
-# -- /
-# - / conditions to obatin item
-@export var obtain_threshold:int
-# FIXME construct ENUM representing different factions 
-@export var required_faction:int
-
-
-
+# static references to child nodes
+@onready var linked_sprite:Sprite2D = $item_sprite
+@onready var interactionspot_child:Interactable = $interactionspot
 
 # run upon instantiating this node in scene
 func _ready():
 	set_item_sprite()
-	# gathering child node
-	var interactionspot_object = get_node("interactionspot")
+	# update available amount 
+	if SingletonPlayer.itemspot_state.has(itemspot_id):
+		print("found saved state, restoring")
+		item_amount = SingletonPlayer.itemspot_state[itemspot_id]
+	
 	# set interaction type for child node
-	interactionspot_object.parent_node = self
-	interactionspot_object.interact_type = interaction_type
+	interactionspot_child.parent_node = self
+	interactionspot_child.interact_type = interaction_type
+	update_visibility()
 
 # checks whether item can be obtained by player 
 # returns true, if possible
@@ -51,27 +42,20 @@ func is_obtainable_by_player() -> bool:
 		return true
 	return false
 
+
 # returns contained item and reduced amount available 
 # returns nothing if requirement is not met 
 func obtain_item() -> Item.ItemType:
 	if is_obtainable_by_player():
 		# can be obtained, returning and updating count for internal representation 
 		item_amount -= 1
+		update_visibility()
+		SingletonPlayer.itemspot_state[itemspot_id] = item_amount
 		return item_type
 	else: 
 		print("not obtainable")
 		# signals an empty return --> wont be saved in inventory
 		return Item.ItemType.NONE
-
-# returns dialogue-String for displaying in dialogue-Box
-# if item obtainable -> return item_dialogue_succes
-# else -> return item_dialogue_failure
-func obtain_dialogue() -> String:
-	if is_obtainable_by_player():
-		return item_dialogue_success
-	else:
-		return item_dialogue_failure
-		
 
 # --- / 
 # -- / VISUALIZATION
@@ -80,8 +64,6 @@ func obtain_dialogue() -> String:
 # deriving sprite to load from item type, stolen from npc_interaction 
 func set_item_sprite():
 	# initialize reference
-	var referenced_sprite:Sprite2D = $Sprite2D
-	
 	var path_to_sprite:String 
 	match item_type:
 		Item.ItemType.EGG: 
@@ -94,4 +76,10 @@ func set_item_sprite():
 			path_to_sprite = "res://assets/art/objects/overworld_items/item_fly.png"
 	# loading texture 
 	var item_sprite:Texture2D = load(path_to_sprite)
-	referenced_sprite.texture = item_sprite
+	linked_sprite.texture = item_sprite
+
+# hides sprite of item if resource depleted
+func update_visibility():
+		linked_sprite.visible = is_obtainable_by_player()
+		
+	

--- a/Arch-enemies/overworld/entities/interaction_overworld/item_interaction.tscn
+++ b/Arch-enemies/overworld/entities/interaction_overworld/item_interaction.tscn
@@ -8,22 +8,7 @@
 script = ExtResource("1_ektp2")
 item_type = 1
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
+[node name="item_sprite" type="Sprite2D" parent="."]
 texture = ExtResource("2_gjeoh")
 
 [node name="interactionspot" parent="." instance=ExtResource("2_agwop")]
-
-[node name="ColorRect" type="ColorRect" parent="."]
-visible = false
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -8.0
-offset_top = -8.0
-offset_right = 8.0
-offset_bottom = 8.0
-grow_horizontal = 2
-grow_vertical = 2
-color = Color(1, 0, 0, 1)

--- a/Arch-enemies/overworld/main_scene_overworld.tscn
+++ b/Arch-enemies/overworld/main_scene_overworld.tscn
@@ -52,18 +52,16 @@ one_shot = true
 [node name="Hazelnut" parent="." instance=ExtResource("6_66i44")]
 position = Vector2(312, 402)
 item_type = 2
-item_dialogue_success = "you got an item!"
-item_dialogue_failure = "no item found"
 
 [node name="Flies" parent="." instance=ExtResource("6_66i44")]
 position = Vector2(348, 255)
 item_type = 3
-item_dialogue_success = "item? "
-item_dialogue_failure = "item :("
+itemspot_id = 1
 
 [node name="Evidence" parent="." instance=ExtResource("6_66i44")]
 position = Vector2(635, 269)
 item_type = 0
+itemspot_id = 2
 
 [node name="Sssstefan" parent="." instance=ExtResource("7_33ud0")]
 position = Vector2(528, 438)

--- a/Arch-enemies/overworld/overworld_test_area.tscn
+++ b/Arch-enemies/overworld/overworld_test_area.tscn
@@ -43,14 +43,10 @@ text = "0 -> 3"
 [node name="item_interaction" parent="." instance=ExtResource("6_ij5ah")]
 position = Vector2(356, 105)
 item_type = 2
-item_dialogue_success = "you got an item!"
-item_dialogue_failure = "no item found"
 
 [node name="item_interaction2" parent="." instance=ExtResource("6_ij5ah")]
 position = Vector2(158, 52)
 item_type = 3
-item_dialogue_success = "item? "
-item_dialogue_failure = "item :("
 
 [node name="NpcInteraction" parent="." instance=ExtResource("7_06f0y")]
 position = Vector2(560, 40)

--- a/Arch-enemies/overworld/scenes/world.tscn
+++ b/Arch-enemies/overworld/scenes/world.tscn
@@ -1,4 +1,5 @@
-[gd_scene load_steps=15 format=3 uid="uid://p30p3o0e473c"]
+[gd_scene load_steps=16 format=3 uid="uid://p30p3o0e473c"]
+
 [ext_resource type="Texture2D" uid="uid://c3k4vrbl35eqt" path="res://assets/art/tilesets/bridge_tileset/bridge_bramble_tiles.png" id="1_kejqx"]
 [ext_resource type="Script" path="res://overworld/scenes/world.gd" id="1_m27wc"]
 [ext_resource type="Texture2D" uid="uid://cmyh0321x42dd" path="res://assets/art/tilesets/overworld_water_edges.png" id="4_itohn"]
@@ -533,4 +534,5 @@ layer_3/tile_data = PackedInt32Array()
 
 [node name="Player" parent="TileMap" instance=ExtResource("5_bmga7")]
 position = Vector2(73, 497)
+
 [connection signal="play_sound" from="TileMap/Player" to="." method="transfer_sound"]

--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -139,6 +139,12 @@ func set_test_animal_inventory() -> Dictionary:
 # --- / 
 # -- / Overworld management 
 
+# tracking items and their state placed in overworld
+# key -> iteminteraction ID, value -> amount of items available
+@onready var itemspot_state:Dictionary = {}
+
+
+
 # denotes amount of islands available
 var TOTAL_ISLANDS:int = 2
 


### PR DESCRIPTION
## Motivation
resolves #179 
- also uses this addition to add _state management_ to maintain item amounts after scene changes occurred
- resolves **visibility** of item once its resource was depleted. 
- removes debug message when interacting with an item
-  removes unused variables from item_interaction

## What was changed/added
- updated `item_interaction`, removed unused variables
- added dictionary to track items and their known amount -> representation as dictionary ( key:itemspotID,value:QuantityAvailable) 
- now binding specific node references \@onready 
- update_visibility sets visibility of sprite denoting an interaction

## Testing
1. open overworld 
2. obtain an item -> should be invisible now!
3. open pause menu and return --> itemspot state prevails 
4. enter bridge scene 
5. return to overworld --> itemspot state prevails 
