### PR TITLE
Overworld | add Npc name to dialogue 

### DIFF
--- a/Arch-enemies/overworld/dialogue/Dialogue.gd
+++ b/Arch-enemies/overworld/dialogue/Dialogue.gd
@@ -8,6 +8,7 @@ var active_dialogue:Dialogue_Data = null
 var current_npc_id : int = 0
 
 # no type here, on startup, this will be configured
+# FIXME declare type
 var npc_control_instance = null
 
 # --- /
@@ -21,8 +22,6 @@ func enter_dialogue(dialogue:Dialogue_Data, npc_id: int):
 	active_dialogue = dialogue
 	# adding quest to players UI
 	SingletonPlayer.add_quest_string(npc_id)
-	# WARNING
-	# Page 0 is reserved for DONE  QUEST DIALOGUE
 	if SingletonPlayer.obtain_npc_quest_state(npc_id):
 		# was done, showing alt text 
 		active_dialogue.select_quest_done_page(0)

--- a/Arch-enemies/overworld/dialogue/DialogueUI.gd
+++ b/Arch-enemies/overworld/dialogue/DialogueUI.gd
@@ -1,14 +1,18 @@
 extends Panel
 
 @onready var window : Window = get_window()
+@onready var text_box:Label = $main_box/content_box/content/label_box/Label
+@onready var npc_name_label:Label = $main_box/content_box/npc_name
+@onready var npc_sprite:Sprite2D = $main_box/image_box/Sprite2D
 
 func _ready():
 	set_text("This a demo dialogue. Nothing to see here.")
 	set_buttons(["Previous", "Next", "Exit"])
+	set_npc_name("display name here")
 	set_image_texture("") # set default picture
 	hide()
 	
-	SingletonPlayer.dialogue.npc_control_instance = self
+	SingletonPlayer.active_dialogue.npc_control_instance = self
 	
 # keep window on the buttom, does not working using canvas layers
 func _process(delta):
@@ -18,15 +22,18 @@ func _process(delta):
 	# print("WINDOW SIZE ", window_size.x, " ", window_size.y, " and y", position.y)
 
 func set_text(body: String):
-	$main_box/content_box/content/label_box/Label.text = body
+	text_box.text = body
+
+func set_npc_name(npc_name:String):
+	npc_name_label.text = npc_name
 
 func set_image_texture(src_path: String):
 	if src_path == "":
-		$main_box/image_box/Sprite2D.texture = load("res://assets/art/dialogue/green.png")
+		# set default image to display
+		npc_sprite.texture = load("res://assets/art/dialogue/green.png")
 		return
-		
-	$main_box/image_box/Sprite2D.scale = Vector2(1.0, 1.0)	
-	$main_box/image_box/Sprite2D.texture = load(src_path)
+	npc_sprite.scale = Vector2(1.0, 1.0)	
+	npc_sprite.texture = load(src_path)
 	
 # null means disabled button, no fixme here xD
 func set_buttons(txt: Array[String]):
@@ -49,14 +56,14 @@ func set_buttons(txt: Array[String]):
 
 func _on_btn_1_pressed():
 	print("NPC INTERACTION BTN 1 PRESSED")
-	SingletonPlayer.dialogue.btn_action(0)
+	SingletonPlayer.active_dialogue.btn_action(0)
 	
 	
 func _on_btn_2_pressed():
 	print("NPC INTERACTION BTN 2 PRESSED")
-	SingletonPlayer.dialogue.btn_action(1)
+	SingletonPlayer.active_dialogue.btn_action(1)
 
 
 func _on_btn_3_pressed():
 	print("NPC INTERACTION BTN 3 PRESSED")
-	SingletonPlayer.dialogue.btn_action(2)
+	SingletonPlayer.active_dialogue.btn_action(2)

--- a/Arch-enemies/overworld/dialogue/DialogueUI.tscn
+++ b/Arch-enemies/overworld/dialogue/DialogueUI.tscn
@@ -50,8 +50,12 @@ layout_mode = 2
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
 
+[node name="npc_name" type="Label" parent="Panel/main_box/content_box"]
+layout_mode = 2
+text = "NAME"
+
 [node name="content" type="HBoxContainer" parent="Panel/main_box/content_box"]
-custom_minimum_size = Vector2(0, 93)
+custom_minimum_size = Vector2(0, 75)
 layout_mode = 2
 
 [node name="label_box" type="BoxContainer" parent="Panel/main_box/content_box/content"]
@@ -59,7 +63,7 @@ custom_minimum_size = Vector2(420, 0)
 layout_mode = 2
 
 [node name="Label" type="Label" parent="Panel/main_box/content_box/content/label_box"]
-custom_minimum_size = Vector2(420, 93)
+custom_minimum_size = Vector2(420, 60)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
 text = "The dialogue system allows the creation of custom dialogues, with buttons and an icon. "

--- a/Arch-enemies/overworld/dialogue/Dialogue_Data.gd
+++ b/Arch-enemies/overworld/dialogue/Dialogue_Data.gd
@@ -7,6 +7,7 @@ var entries: Array[Dialogue_Entry] = []
 var quest_done_entries: Array[Dialogue_Entry] = []
 var currentEntry: int = 0
 var finished: bool = false
+var npc_name:String = ""
 
 # --- /
 # -- / class constructor 
@@ -14,20 +15,23 @@ func _init():
 	pass
 
 # works as "select_page()" but displays all entries from 
+# FIXME same as select_page 
+# FIXME both could be merged and dynamiccaly take either quest_done_entries / entries 
 func select_quest_done_page(page:int):
 	if page >= len(quest_done_entries):
 		print("ERROR, INVALID PAGE NUMBER SUPPLIED")
 		return
 	currentEntry = page
 	# of course, no data type here, idk how to work with signals
-	var control_instance = SingletonPlayer.dialogue.npc_control_instance
+	var control_instance = SingletonPlayer.active_dialogue.npc_control_instance
 	
 	# will always start from start of it 
 	var entry: Dialogue_Entry = quest_done_entries[0]
 	
 	# set title and content
 	control_instance.set_text(entry.content())
-	
+	# set name of npc 
+	control_instance.set_npc_name(npc_name)
 	# set button text
 	control_instance.set_buttons(entry.btn_text())
 	
@@ -45,12 +49,14 @@ func select_page(page: int):
 	currentEntry = page
 	
 	# of course, no data type here, idk how to work with signals
-	var control_instance = SingletonPlayer.dialogue.npc_control_instance
+	var control_instance = SingletonPlayer.active_dialogue.npc_control_instance
 	var entry: Dialogue_Entry = entries[currentEntry]
 	# set title and content
 	control_instance.set_text(entry.content())
 	# set button text
 	control_instance.set_buttons(entry.btn_text())
+	# set name of npc 
+	control_instance.set_npc_name(npc_name)
 	# set image resource
 	control_instance.set_image_texture(entry.image_src())
 	# show panel

--- a/Arch-enemies/overworld/dialogues/QuestTrackingNPC/QuestTrackingNPC.gd
+++ b/Arch-enemies/overworld/dialogues/QuestTrackingNPC/QuestTrackingNPC.gd
@@ -17,14 +17,6 @@ func _init():
 	
 	# test case
 	# querying the current state of quests 
-	
-	# FIXME no reason to initialize if overworld was not loaded -> no npc object available
-	# key: quest-string -> value: state:Boolean
-	#var quest_list:Dictionary = SingletonPlayer.obtain_all_quest_states()
-	#var unsolved_quests:Array[String] = extract_unsolved_quests(quest_list)
-	#
-	#print(unsolved_quests)
-	#insert_quests(unsolved_quests)
 
 # takes dictionary of quests and converts it to array of their strings 
 #

--- a/Arch-enemies/overworld/dialogues/test_dialogue/Page-Quest-Done1.gd
+++ b/Arch-enemies/overworld/dialogues/test_dialogue/Page-Quest-Done1.gd
@@ -26,5 +26,5 @@ func btn_action(btn: int):
 			
 	if btn == 0:
 		print("executing button action")
-		SingletonPlayer.dialogue.finish_dialogue()
+		SingletonPlayer.active_dialogue.finish_dialogue()
 		SingletonPlayer.exit_dialogue()

--- a/Arch-enemies/overworld/dialogues/test_dialogue/Page1.gd
+++ b/Arch-enemies/overworld/dialogues/test_dialogue/Page1.gd
@@ -4,11 +4,6 @@ extends Dialogue_Entry
 class_name Page1
 
 
-# --- /
-# -- / class constructor 
-func _init():
-	pass
-
 func content() -> String:
 	return "This is the first page of the example dialogue. Navigate to the next page, by pressing the button"
 
@@ -25,4 +20,4 @@ func btn_action(btn: int):
 		SingletonPlayer.exit_dialogue()
 		
 	if btn == 1:
-		SingletonPlayer.dialogue.select_page(1)
+		SingletonPlayer.active_dialogue.select_page(1)

--- a/Arch-enemies/overworld/dialogues/test_dialogue/Page2.gd
+++ b/Arch-enemies/overworld/dialogues/test_dialogue/Page2.gd
@@ -23,10 +23,10 @@ func btn_text() -> Array[String]:
 # btn button in from left to right, starting with 0
 func btn_action(btn: int):
 	if btn == 0:
-		SingletonPlayer.dialogue.select_page(0)	
+		SingletonPlayer.active_dialogue.select_page(0)	
 		
 	if btn == 1:
-		SingletonPlayer.dialogue.select_page(2)
+		SingletonPlayer.active_dialogue.select_page(2)
 		
 	if btn == 2:
 		SingletonPlayer.exit_dialogue()

--- a/Arch-enemies/overworld/dialogues/test_dialogue/Page3.gd
+++ b/Arch-enemies/overworld/dialogues/test_dialogue/Page3.gd
@@ -24,8 +24,8 @@ func btn_text() -> Array[String]:
 # btn button in from left to right, starting with 0
 func btn_action(btn: int):
 	if btn == 0:
-		SingletonPlayer.dialogue.select_page(1)
+		SingletonPlayer.active_dialogue.select_page(1)
 			
 	if btn == 1:
-		SingletonPlayer.dialogue.finish_dialogue()
+		SingletonPlayer.active_dialogue.finish_dialogue()
 		SingletonPlayer.exit_dialogue()

--- a/Arch-enemies/overworld/entities/interaction_overworld/npc_interaction.gd
+++ b/Arch-enemies/overworld/entities/interaction_overworld/npc_interaction.gd
@@ -73,6 +73,10 @@ func _ready():
 	
 	# constructing NPC accordingly
 	npc_object = create_npc()
+	# update name for dialogue associated with NPC! 
+	# FIXME not a good solution because we leave the scope of where this should be done
+	# WARNING npc_interaction should not take care, even know about a npc_dialogue!
+	SingletonPlayer.set_dialogue_npc_name(npc_id)
 	#print(npc_object.stringify_quest())
 
 # --- / 

--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -262,6 +262,11 @@ func obtain_npc_quest_state(npc_id) -> bool:
 	#print("current state of quest" + str(quest_state))
 	return quest_state
 
+func obtain_npc_name(npc_id) -> String:
+	var npc_object:NPC_interaction = obtain_npc_object(npc_id)
+	var npc_name:String = npc_object.obtain_name()
+	return npc_name
+
 # queries all quests and their state
 # returns dictionary with following structure
 # key: quest-string -> value: state:Boolean
@@ -392,7 +397,15 @@ func save_profile_configuration():
 	4 : ExampleData.new(),
 }
 
-@onready var dialogue: Dialogue = Dialogue.new()
+func set_dialogue_npc_name(npc_id:int):
+	if not npc_dialogues.has(npc_id):
+		return 
+	var npc_name:String = obtain_npc_name(npc_id)
+	var npc_dialogue = npc_dialogues[npc_id]
+	npc_dialogue.npc_name = npc_name
+	
+
+@onready var active_dialogue: Dialogue = Dialogue.new()
 
 # checks whether a npc has a dialogue linked to it
 func has_dialogue(npc_id:int) -> bool:
@@ -411,7 +424,8 @@ func prepare_dialogue(npc_id:int):
 					var active_quests:Dictionary = active_tracked_quests
 					dialogue_object.update_dialogue(active_quests)
 	var data : Dialogue_Data = npc_dialogues[npc_id]
-	dialogue.enter_dialogue(data, npc_id)
+	active_dialogue.enter_dialogue(data, npc_id)
+
 
 # returns whether the dialogue has been finished.
 # finished is not just given by closing the dialogue window.
@@ -428,11 +442,11 @@ func obtain_dialogue(npc_id:int):
 
 # returns true when the player is currently in dialogue
 func navigation_in_dialogue() -> bool:
-	return dialogue.in_dialogue()
+	return active_dialogue.in_dialogue()
 
 # ends dialogue
 func exit_dialogue():
-	dialogue.exit_dialogue()
+	active_dialogue.exit_dialogue()
 
 
 


### PR DESCRIPTION
## Motivation
Adds name of the given npc to every dialogue box they have.
Does not resolve a specific issue ( was discussed internally )

Also went over the implementation of the Dialogue-System and added / rewrote some minor portions to improve readability. 

**Warning**:
With this change names are set the following: 
1. each Dialogue contains a variable "npc_name" which denotes the name to display. Its "" at first, so empty
2. To update this dynamically we have to set this name whenever the npcs linked to the dialogue are initialized ( before that we cannot obtain their name cus its contained in their construction / object, which is only available after they've been loaded at least once ) 
3. then the name is statically taken from the internal variable set in `Dialogue_Data`

## What was changed/added
- renamed few things in `Dialogue` `Dialogue_Data` 
- added method to retrieve npc_name 
- added method to set npc_name from `npc_interaction` --> upon `_ready` is executed 
- added _Warning_ to improve this later --> setting it in npc_interaction leaves its scope / should be done elsewhere in my opinion

## Testing
Try talking to the npcs available:

![image](https://github.com/mango-gremlin/arch-enemies/assets/63316422/d50f1d7c-ebed-46e6-a90c-5bd65d934871)

![image](https://github.com/mango-gremlin/arch-enemies/assets/63316422/aabb89b8-0e59-4fca-ae76-d2c7cb325cae)

![image](https://github.com/mango-gremlin/arch-enemies/assets/63316422/59d25398-ddcd-4412-ba8a-f812585d2273)
