### PR TITLE
overworld | improve deer npc, handling undone / done quest dialogues 

### DIFF
--- a/Arch-enemies/overworld/dialogue/Dialogue.gd
+++ b/Arch-enemies/overworld/dialogue/Dialogue.gd
@@ -28,9 +28,7 @@ func enter_dialogue(dialogue:Dialogue_Data, npc_id: int):
 	print(dialogue_state)
 	if (quest_state and dialogue_state):
 		# was done, showing alt text 
-		print("quest resolved now")
-		active_dialogue.select_quest_done_page(0)
-		return
+		active_dialogue.set_quest_dialogue_done()
 	
 	active_dialogue.select_page(0)
 

--- a/Arch-enemies/overworld/dialogue/Dialogue_Data.gd
+++ b/Arch-enemies/overworld/dialogue/Dialogue_Data.gd
@@ -11,6 +11,9 @@ var currentEntry: int = 0
 var finished: bool = false
 var npc_name:String = ""
 
+# used to disable two dialogue options and only use the dialogue_done entries
+func deactivate_undone_pages():
+	finished = true
 
 # if called it sets the active dialogue to be the quest_done dialogue
 func set_quest_dialogue_done():

--- a/Arch-enemies/overworld/dialogue/Dialogue_Data.gd
+++ b/Arch-enemies/overworld/dialogue/Dialogue_Data.gd
@@ -3,46 +3,22 @@
 # representation of the complete dialog
 class_name Dialogue_Data
 
-var entries: Array[Dialogue_Entry] = []
+var quest_undone_entries: Array[Dialogue_Entry] = []
 var quest_done_entries: Array[Dialogue_Entry] = []
+# denotes the actively selected set of pages
+var active_pages:Array[Dialogue_Entry] = []
 var currentEntry: int = 0
 var finished: bool = false
 var npc_name:String = ""
 
-# --- /
-# -- / class constructor 
-func _init():
-	pass
 
-# works as "select_page()" but displays all entries from 
-# FIXME same as select_page 
-# FIXME both could be merged and dynamiccaly take either quest_done_entries / entries 
-func select_quest_done_page(page:int):
-	if page >= len(quest_done_entries):
-		print("ERROR, INVALID PAGE NUMBER SUPPLIED")
-		return
-	currentEntry = page
-	# of course, no data type here, idk how to work with signals
-	var control_instance = SingletonPlayer.active_dialogue.npc_control_instance
+# if called it sets the active dialogue to be the quest_done dialogue
+func set_quest_dialogue_done():
+	active_pages = quest_done_entries
 	
-	# will always start from start of it 
-	var entry: Dialogue_Entry = quest_done_entries[0]
-	
-	# set title and content
-	control_instance.set_text(entry.content())
-	# set name of npc 
-	control_instance.set_npc_name(npc_name)
-	# set button text
-	control_instance.set_buttons(entry.btn_text())
-	
-	# set image resource
-	control_instance.set_image_texture(entry.image_src())
-	
-	# show panel
-	control_instance.show()
 
 func select_page(page: int):
-	if page >= len(entries):
+	if page >= len(active_pages):
 		print("ERROR, INVALID PAGE NUMBER SUPPLIED")
 		return
 	
@@ -50,7 +26,7 @@ func select_page(page: int):
 	
 	# of course, no data type here, idk how to work with signals
 	var control_instance = SingletonPlayer.active_dialogue.npc_control_instance
-	var entry: Dialogue_Entry = entries[currentEntry]
+	var entry: Dialogue_Entry = active_pages[currentEntry]
 	# set title and content
 	control_instance.set_text(entry.content())
 	# set button text
@@ -71,4 +47,4 @@ func btn_action(btn: int,done_state:bool):
 		quest_done_entries[currentEntry].btn_action(btn)
 		return
 	print("non finished condition")
-	entries[currentEntry].btn_action(btn)
+	active_pages[currentEntry].btn_action(btn)

--- a/Arch-enemies/overworld/dialogues/DynamicDialogue/DynamicDialogue.gd
+++ b/Arch-enemies/overworld/dialogues/DynamicDialogue/DynamicDialogue.gd
@@ -11,7 +11,7 @@ func _init(_empty_image: String, _empty_msg: String, _quest_done_image: String, 
 	src_image = _empty_image
 	empty_msg = _empty_msg
 	
-	entries = [
+	quest_undone_entries = [
 		EmptyDynamicDialoguePage.new(_empty_image, _empty_msg)
 		]
 		
@@ -19,18 +19,28 @@ func _init(_empty_image: String, _empty_msg: String, _quest_done_image: String, 
 		DynamicQuestResolved.new(_quest_done_image, _quest_done_msg)
 	]
 
-func insert_pages(pages:Array[DynamicPage]):
-	if len(pages) == 0:
-		entries = [EmptyDynamicDialoguePage.new(src_image, empty_msg)]
-		return
-		
-	var max_page = len(pages) - 1
-		
-	entries = []
-	var index = 0
-	
-	for dynamic_page in pages:
-		# if its the last page we have to update the dialogue-state at the end
-		var is_last_page:bool = index ==  max_page
-		entries.append(DynamigPageImpl.new(dynamic_page.__content, dynamic_page.src_image, index, max_page,is_last_page))
+func insert_pages(unsolved_pages:Array[DynamicPage],solved_pages:Array[DynamicPage]):
+	#if len(pages) == 0:
+		#entries = [EmptyDynamicDialoguePage.new(src_image, empty_msg)]
+		#ret?urn
+	# adding entries for unsolved_page
+	add_dialogue_content(false,unsolved_pages)
+	add_dialogue_content(true, solved_pages)
+	# setting default entry to correctly set the dialogue available
+	active_pages = quest_undone_entries
+
+func add_dialogue_content(quest_done_dialogue:bool,retrieved_pages:Array[DynamicPage]):
+	var generated_pages: Array[Dialogue_Entry] = []
+	var max_page:int = len(retrieved_pages)-1
+	var index:int = 0
+	for page_entry:DynamicPage in retrieved_pages:
+		var is_last_page:bool = index == max_page
+		generated_pages.append(DynamigPageImpl.new(page_entry.__content, page_entry.src_image, index, max_page,is_last_page))
 		index += 1
+	# adding to corresponding entry
+	if quest_done_dialogue:
+		quest_done_entries = generated_pages
+		return
+	# setting unsolved_dialogue
+	quest_undone_entries = generated_pages
+	return

--- a/Arch-enemies/overworld/dialogues/QuestTrackingNPC/QuestTrackingNPC.gd
+++ b/Arch-enemies/overworld/dialogues/QuestTrackingNPC/QuestTrackingNPC.gd
@@ -44,10 +44,10 @@ func insert_quests(quests:Array[String]):
 		quest_undone_entries = [NoQuestFoundPage.new()]
 		return
 		
-	var max_page = len(quests)
+	var max_page = len(quests) -1
 	
 	quest_undone_entries = []
-	var index = 1
+	var index = 0
 	
 	for quest in quests:
 		print("adding quest to entry")

--- a/Arch-enemies/overworld/dialogues/QuestTrackingNPC/QuestTrackingNPC.gd
+++ b/Arch-enemies/overworld/dialogues/QuestTrackingNPC/QuestTrackingNPC.gd
@@ -2,12 +2,12 @@ extends Dialogue_Data
 
 
 class_name QuestTrackNPC
-
+var default_undone_text:String
 # --- /
 # -- / class constructor 
 func _init():
 	print("initialize quest tracker")
-	var default_undone_text: String = "I will not join you >:( The others need to do something for once. Then maybe I will help."
+	default_undone_text = "I will not join you >:( The others need to do something for once. Then maybe I will help."
 	quest_undone_entries = [
 		QuestPage.new(default_undone_text,0,0)
 		]
@@ -17,7 +17,7 @@ func _init():
 	]
 	active_pages = quest_undone_entries
 	# setting dialogue finish to true
-	finished = true
+	deactivate_undone_pages()
 	
 	# test case
 	# querying the current state of quests 
@@ -41,17 +41,12 @@ func update_dialogue(quest_dict:Dictionary):
 	insert_quests(unsolved_quests)
 
 func insert_quests(quests:Array[String]):
-	#if len(quests) == 0:
-		#quest_undone_entries = [NoQuestFoundPage.new()]
-		#return
-	# extracting initial dialogue for undone quest 
-	# to reconstruct it with updated length
-	var dialogue_undone:String = quest_undone_entries[0].quest
 	var max_page = len(quests) 
 	
 	quest_undone_entries = []
 	var index = 1
-	quest_undone_entries.append(QuestPage.new(dialogue_undone,0,max_page))
+	# adding base entry
+	quest_undone_entries.append(QuestPage.new(default_undone_text,0,max_page))
 	for quest in quests:
 		print("adding quest to entry")
 		quest_undone_entries.append(QuestPage.new(quest, index, max_page))

--- a/Arch-enemies/overworld/dialogues/QuestTrackingNPC/QuestTrackingNPC.gd
+++ b/Arch-enemies/overworld/dialogues/QuestTrackingNPC/QuestTrackingNPC.gd
@@ -7,13 +7,16 @@ class_name QuestTrackNPC
 # -- / class constructor 
 func _init():
 	print("initialize quest tracker")
-	entries = [
+	quest_undone_entries = [
 		NoQuestFoundPage.new()
 		]
 	# contains all entries that are displayed when the objective was solved 
 	quest_done_entries = [
 		NPC_TRACKER_PageQuestDone1.new()
 	]
+	active_pages = quest_undone_entries
+	# setting dialogue finish to true
+	finished = true
 	
 	# test case
 	# querying the current state of quests 
@@ -38,14 +41,17 @@ func update_dialogue(quest_dict:Dictionary):
 
 func insert_quests(quests:Array[String]):
 	if len(quests) == 0:
-		entries = [NoQuestFoundPage.new()]
+		quest_undone_entries = [NoQuestFoundPage.new()]
 		return
 		
-	var max_page = len(quests) - 1
-		
-	entries = []
-	var index = 0
+	var max_page = len(quests)
+	
+	quest_undone_entries = []
+	var index = 1
 	
 	for quest in quests:
-		entries.append(QuestPage.new(quest, index, max_page))
+		print("adding quest to entry")
+		quest_undone_entries.append(QuestPage.new(quest, index, max_page))
 		index += 1
+	# updating active dialogue entry
+	active_pages = quest_undone_entries

--- a/Arch-enemies/overworld/dialogues/QuestTrackingNPC/QuestTrackingNPC.gd
+++ b/Arch-enemies/overworld/dialogues/QuestTrackingNPC/QuestTrackingNPC.gd
@@ -7,8 +7,9 @@ class_name QuestTrackNPC
 # -- / class constructor 
 func _init():
 	print("initialize quest tracker")
+	var default_undone_text: String = "I will not join you >:( The others need to do something for once. Then maybe I will help."
 	quest_undone_entries = [
-		NoQuestFoundPage.new()
+		QuestPage.new(default_undone_text,0,0)
 		]
 	# contains all entries that are displayed when the objective was solved 
 	quest_done_entries = [
@@ -40,15 +41,17 @@ func update_dialogue(quest_dict:Dictionary):
 	insert_quests(unsolved_quests)
 
 func insert_quests(quests:Array[String]):
-	if len(quests) == 0:
-		quest_undone_entries = [NoQuestFoundPage.new()]
-		return
-		
-	var max_page = len(quests) -1
+	#if len(quests) == 0:
+		#quest_undone_entries = [NoQuestFoundPage.new()]
+		#return
+	# extracting initial dialogue for undone quest 
+	# to reconstruct it with updated length
+	var dialogue_undone:String = quest_undone_entries[0].quest
+	var max_page = len(quests) 
 	
 	quest_undone_entries = []
-	var index = 0
-	
+	var index = 1
+	quest_undone_entries.append(QuestPage.new(dialogue_undone,0,max_page))
 	for quest in quests:
 		print("adding quest to entry")
 		quest_undone_entries.append(QuestPage.new(quest, index, max_page))

--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -404,8 +404,9 @@ var fox_portrait = "res://assets/art/characters/portraits/Portrait_Fox.png"
 
 # ID 1: Stefan
 func dialogue_snake_stefan():
+	# FIXME remove initialization that will be overwritten anyway!
 	var dynamic_dialogue = DynamicDialogue.new(spider_portrait, "no page here",
-	snake_portrait, "Is zzat an eegg?? Oh zzat's szzoo niczze of youu! I will help you, but don't get too closzze to me or I might take a bite. I can't help it, it'szz a reflexzz.")
+	snake_portrait, "")
 	
 	var unsolved_pages:Array[DynamicPage] = [
 		DynamicPage.new("Hello zzere little foxzz, why are you bozzering mee?", snake_portrait),
@@ -417,7 +418,7 @@ func dialogue_snake_stefan():
 		DynamicPage.new("Ohh zzat would be very kind! Of courszze I would help you... aszz long as I have szzomething to szzwallow and digeszzt.", snake_portrait),
 	]
 	var solved_pages:Array[DynamicPage] = [
-		DynamicPage.new("this si done ...",snake_portrait)
+		DynamicPage.new("Is zzat an eegg?? Oh zzat's szzoo niczze of youu! I will help you, but don't get too closzze to me or I might take a bite. I can't help it, it'szz a reflexzz.",snake_portrait)
 	]
 	
 	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)
@@ -426,8 +427,9 @@ func dialogue_snake_stefan():
 
 # ID 2: Grandfather Longlegs
 func dialogue_spider_grandpa():
+	# FIXME remove initialization that will be overwritten anyway!
 	var dynamic_dialogue = DynamicDialogue.new(spider_portrait, "no page here",
-	spider_portrait, "Many thanks, young lad. Now that my family is cared for I will aid you on your quest.")
+	spider_portrait, "")
 	
 	var unsolved_pages:Array[DynamicPage] = [
 		DynamicPage.new("Can you help solve the flooding issue?", fox_portrait),
@@ -437,7 +439,7 @@ func dialogue_spider_grandpa():
 	]
 	
 	var solved_pages:Array[DynamicPage] = [
-		DynamicPage.new("this si done ...",spider_portrait)
+		DynamicPage.new("Many thanks, young lad. Now that my family is cared for I will aid you on your quest.",spider_portrait)
 	]
 	
 	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)
@@ -447,8 +449,9 @@ func dialogue_spider_grandpa():
 
 # ID 3: Esther Egg Squirrel
 func dialogue_squirrel_egg():
+	# FIXME remove initialization that will be overwritten anyway!
 	var dynamic_dialogue = DynamicDialogue.new(squirrel_portrait, "no page here",
-	squirrel_portrait, "This is way better than the purple one! Ill take this one and you get the purple one.")
+	squirrel_portrait, "")
 	
 	var unsolved_pages:Array[DynamicPage] = [
 		DynamicPage.new("Behold!", squirrel_portrait),
@@ -458,7 +461,7 @@ func dialogue_squirrel_egg():
 	]
 	
 	var solved_pages:Array[DynamicPage] = [
-		DynamicPage.new("this si done ...",squirrel_portrait)
+		DynamicPage.new("This is way better than the purple one! Ill take this one and you get the purple one.",squirrel_portrait)
 	]
 	
 	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)
@@ -468,8 +471,9 @@ func dialogue_squirrel_egg():
 
 # ID 4: Ol'Nutter
 func dialogue_squirrel_ol_nutter():
+	# FIXME remove initialization that will be overwritten anyway!
 	var dynamic_dialogue = DynamicDialogue.new(squirrel_nutter_portrait, "no page here",
-	squirrel_nutter_portrait, "<Excited Squeaking>...this is incredible! Now everyone will believe in the NUT! We can rise up against Big Frog! We'll join your noble cause!")
+	squirrel_nutter_portrait, "")
 	
 	var unsolved_pages:Array[DynamicPage] = [
 		DynamicPage.new("Did you see that nut-damned frog at the meeting back there?! I tell you, that creature is behind everything! ", squirrel_nutter_portrait),
@@ -487,7 +491,7 @@ func dialogue_squirrel_ol_nutter():
 	]
 	
 	var solved_pages:Array[DynamicPage] = [
-		DynamicPage.new("this si done ...",squirrel_nutter_portrait)
+		DynamicPage.new("<Excited Squeaking>...this is incredible! Now everyone will believe in the NUT! We can rise up against Big Frog! We'll join your noble cause!",squirrel_nutter_portrait)
 	]
 	
 	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)
@@ -497,8 +501,9 @@ func dialogue_squirrel_ol_nutter():
 
 # ID 5: Toadally Anonymous
 func dialogue_starting_conflict():
+	# FIXME remove initialization that will be overwritten anyway!
 	var dynamic_dialogue = DynamicDialogue.new(frog_portrait, "no page here",
-	frog_portrait, "... seems like no one wants to help you, hehehehehehehe ... they're playing right into my webbed hands ...")
+	frog_portrait, "")
 	
 	var unsolved_pages:Array[DynamicPage] = [
 		DynamicPage.new("< You hear a loud discussion amongst different animals... >", fox_portrait),
@@ -517,7 +522,7 @@ func dialogue_starting_conflict():
 		#DynamicPage.new("<<< due to a series of unfortunate events, the fox must interact with the toadally anonymous individual again after finishing this dialogue. Thank you! >>>", frog_portrait),
 	]
 	var solved_pages:Array[DynamicPage] = [
-		DynamicPage.new("go away please!",frog_portrait)
+		DynamicPage.new("... seems like no one wants to help you, hehehehehehehe ... they're playing right into my webbed hands ...",frog_portrait)
 	]
 	
 	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)
@@ -528,7 +533,7 @@ func dialogue_starting_conflict():
 # ID 6: Final Thank you
 func dialogue_final():
 	var dynamic_dialogue = DynamicDialogue.new(squirrel_portrait, "no page here",
-	frog_portrait, "Thanks for playing!")
+	frog_portrait, "")
 	
 	var unsolved_pages:Array[DynamicPage] = [
 		DynamicPage.new("If you ran into any problems while playing, please do not hesitate to tell us.", frog_portrait),
@@ -538,7 +543,7 @@ func dialogue_final():
 	]
 	
 	var solved_pages:Array[DynamicPage] = [
-		DynamicPage.new("this si done ...",snake_portrait)
+		DynamicPage.new("Thanks for playing!",snake_portrait)
 	]
 	
 	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)

--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -109,6 +109,7 @@ func use_item(requested_item:Item.ItemType):
 	if request_item(requested_item):
 		var queried_item = item_inventory[requested_item]
 		item_inventory[requested_item] = queried_item -1
+	updated_item_inventory.emit(item_inventory)
 
 # --- / 
 # -- / animal inventory
@@ -406,7 +407,7 @@ func dialogue_snake_stefan():
 	var dynamic_dialogue = DynamicDialogue.new(spider_portrait, "no page here",
 	snake_portrait, "Is zzat an eegg?? Oh zzat's szzoo niczze of youu! I will help you, but don't get too closzze to me or I might take a bite. I can't help it, it'szz a reflexzz.")
 	
-	var pages:Array[DynamicPage] = [
+	var unsolved_pages:Array[DynamicPage] = [
 		DynamicPage.new("Hello zzere little foxzz, why are you bozzering mee?", snake_portrait),
 		DynamicPage.new("Hi, we want your help for fixing the dam to prevent more floods!", fox_portrait),
 		DynamicPage.new("Szzoo you want my help, but what do I get from zzat? I can szzwim you know, szoo I don't really caree about zze water.", snake_portrait),
@@ -415,8 +416,11 @@ func dialogue_snake_stefan():
 		DynamicPage.new("Maybe I can find something else you could eat. Would you help us then?", fox_portrait),
 		DynamicPage.new("Ohh zzat would be very kind! Of courszze I would help you... aszz long as I have szzomething to szzwallow and digeszzt.", snake_portrait),
 	]
+	var solved_pages:Array[DynamicPage] = [
+		DynamicPage.new("this si done ...",snake_portrait)
+	]
 	
-	dynamic_dialogue.insert_pages(pages)
+	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)
 	
 	return dynamic_dialogue
 
@@ -425,14 +429,19 @@ func dialogue_spider_grandpa():
 	var dynamic_dialogue = DynamicDialogue.new(spider_portrait, "no page here",
 	spider_portrait, "Many thanks, young lad. Now that my family is cared for I will aid you on your quest.")
 	
-	var pages:Array[DynamicPage] = [
+	var unsolved_pages:Array[DynamicPage] = [
 		DynamicPage.new("Can you help solve the flooding issue?", fox_portrait),
 		DynamicPage.new("You young whipper-snapper, get off my net!", spider_portrait), 
 		DynamicPage.new("The last round of rowdy blaggards already scattered my flies and I need to gather new ones to feed my 6582 grandchildren!", spider_portrait),
 		DynamicPage.new("Once they are cared for I will consider helping you.", spider_portrait),
 	]
 	
-	dynamic_dialogue.insert_pages(pages)
+	var solved_pages:Array[DynamicPage] = [
+		DynamicPage.new("this si done ...",spider_portrait)
+	]
+	
+	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)
+	
 	
 	return dynamic_dialogue
 
@@ -441,14 +450,19 @@ func dialogue_squirrel_egg():
 	var dynamic_dialogue = DynamicDialogue.new(squirrel_portrait, "no page here",
 	squirrel_portrait, "This is way better than the purple one! Ill take this one and you get the purple one.")
 	
-	var pages:Array[DynamicPage] = [
+	var unsolved_pages:Array[DynamicPage] = [
 		DynamicPage.new("Behold!", squirrel_portrait),
 		DynamicPage.new("I have found something very special: a purple striped walnut of impressive size! A magnificent specimen.", squirrel_portrait),
 		DynamicPage.new("... Thats an egg.", fox_portrait),
 		DynamicPage.new("What! Impossible! I wanted a nut! Bring me one so I can check.", squirrel_portrait),
 	]
 	
-	dynamic_dialogue.insert_pages(pages)
+	var solved_pages:Array[DynamicPage] = [
+		DynamicPage.new("this si done ...",squirrel_portrait)
+	]
+	
+	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)
+	
 	
 	return dynamic_dialogue
 
@@ -457,7 +471,7 @@ func dialogue_squirrel_ol_nutter():
 	var dynamic_dialogue = DynamicDialogue.new(squirrel_nutter_portrait, "no page here",
 	squirrel_nutter_portrait, "<Excited Squeaking>...this is incredible! Now everyone will believe in the NUT! We can rise up against Big Frog! We'll join your noble cause!")
 	
-	var pages:Array[DynamicPage] = [
+	var unsolved_pages:Array[DynamicPage] = [
 		DynamicPage.new("Did you see that nut-damned frog at the meeting back there?! I tell you, that creature is behind everything! ", squirrel_nutter_portrait),
 		DynamicPage.new("Well it seems like it wanted everyone to argue, instead of helping me.", fox_portrait),
 		DynamicPage.new("HA! Just like I told them! But does anyone believe me? NO! ", squirrel_nutter_portrait),
@@ -472,7 +486,12 @@ func dialogue_squirrel_ol_nutter():
 		DynamicPage.new("Can you travel to the frog-invested island to the east, and bring some evidence to me? I'm sure the entirety of NUT will see your noble cause!", squirrel_nutter_portrait)
 	]
 	
-	dynamic_dialogue.insert_pages(pages)
+	var solved_pages:Array[DynamicPage] = [
+		DynamicPage.new("this si done ...",squirrel_nutter_portrait)
+	]
+	
+	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)
+	
 	
 	return dynamic_dialogue
 
@@ -481,7 +500,7 @@ func dialogue_starting_conflict():
 	var dynamic_dialogue = DynamicDialogue.new(frog_portrait, "no page here",
 	frog_portrait, "... seems like no one wants to help you, hehehehehehehe ... they're playing right into my webbed hands ...")
 	
-	var pages:Array[DynamicPage] = [
+	var unsolved_pages:Array[DynamicPage] = [
 		DynamicPage.new("< You hear a loud discussion amongst different animals... >", fox_portrait),
 		DynamicPage.new("< You and your friends decide to investigate >", fox_portrait),
 		DynamicPage.new("My precious webs are broken! The travesty! Watch your step, youngins!", spider_portrait),
@@ -497,8 +516,12 @@ func dialogue_starting_conflict():
 		DynamicPage.new("... hehehehehehehehehehehehehehe ...", frog_portrait),
 		#DynamicPage.new("<<< due to a series of unfortunate events, the fox must interact with the toadally anonymous individual again after finishing this dialogue. Thank you! >>>", frog_portrait),
 	]
+	var solved_pages:Array[DynamicPage] = [
+		DynamicPage.new("go away please!",frog_portrait)
+	]
 	
-	dynamic_dialogue.insert_pages(pages)
+	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)
+	
 	
 	return dynamic_dialogue
 	
@@ -507,14 +530,19 @@ func dialogue_final():
 	var dynamic_dialogue = DynamicDialogue.new(squirrel_portrait, "no page here",
 	frog_portrait, "Thanks for playing!")
 	
-	var pages:Array[DynamicPage] = [
+	var unsolved_pages:Array[DynamicPage] = [
 		DynamicPage.new("If you ran into any problems while playing, please do not hesitate to tell us.", frog_portrait),
 		DynamicPage.new("We also would like to know what you thought of the game in general:", frog_portrait),
 		DynamicPage.new("- understandability - difficulty (esp: how many animals did you use? Did you have too many?) - fun/boring - suggestions -", frog_portrait),
 		DynamicPage.new("Thanks for playing our game! We really appreciate it!", frog_portrait),
 	]
 	
-	dynamic_dialogue.insert_pages(pages)
+	var solved_pages:Array[DynamicPage] = [
+		DynamicPage.new("this si done ...",snake_portrait)
+	]
+	
+	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)
+	
 	
 	return dynamic_dialogue
 
@@ -556,6 +584,7 @@ func prepare_dialogue(npc_id:int):
 					var dialogue_object = obtain_dialogue(npc_id)
 					var active_quests:Dictionary = active_tracked_quests
 					dialogue_object.update_dialogue(active_quests)
+					print("updated npc")
 	var data : Dialogue_Data = npc_dialogues[npc_id]
 	active_dialogue.enter_dialogue(data, npc_id)
 


### PR DESCRIPTION
## Motivation
resolves #308  
fixes **deer** not showing their quest-done dialogue after all quest were done 
simplifies inserting done/undone quest pages into deer NPC

**does not resolve**:
- ~~questTracker : always show first page ( that it did not join the group yet ) --> will be done before closing this~~ done 

## What was changed/added
I've changed how the **active** set of pages is selected by adding `var active_pages:Array[Dialogue_Entry] = []` in Dialogue_Data. It denotes which set of pages is actively displayed when **entering a dialogue**
**It defaults** to the _undone-quest_. 
--> once the quest was done it will then be **updated** to the quest_done pages and those will be displayed.

This allows to **remove** `select_quest_done` as it mimics `select_page()`.

### update for WIKI:

**Creating a new Dialogue**:
to create a new dialogue we have to decide on the following: 
1. will the NPC have a quest ? -> if not we can disable the dialogue that would be shown if its undone!
2. how many pages do I want
3. which assets to add for each party speaking ?

> If this was decided you're good to go! 

Adding a new entry is done in a given file that will generate and add the entries upon starting the game!
Its found in `/overworld/dialogues/overworld_dialogues.gd`

within we require the following information:
- the npc_id --> denoting the NPC placed in the overworld ( to bind both ) 
- our story 
- the assets to add 

now we have to create a new function:
```
func dialogue_<npc_id>l() -> DynamicDialogue :
        # instantiate dialogue 
	var dynamic_dialogue = DynamicDialogue.new( )
	
	var unsolved_pages:Array[DynamicPage] = [
		DynamicPage.new("text1",image_to_display),
		DynamicPage.new("text2",image_to_display),
		...
	]
	
	var solved_pages:Array[DynamicPage] = [
		DynamicPage.new("done 1",image_to_display),
		DynamicPage.new("done 2",image_to_display),
		...
	]
	# inserting entries
	dynamic_dialogue.insert_pages(unsolved_pages,solved_pages)
	
	# returning
	return dynamic_dialogue
```

> This will create a dialogue that contains two dialogues ( one before the quest was done ( and you have not finished speaking to it )  and one that is displayed once you've finished the dialogue ) 

### Special traits:

> **Consider** you only want **one** dialogue to play ( i.e  for an intro scene or just some npc to talk to ): 
> We don't require two dialogues anymore, because we are only using one! 
> This also requires the **NPC to have no quest, so check this before attempting to add the dialogue!**

To accomplish this we have to do the following
1. take aboves _template_ but don't fill the `unsolved_pages` array, because we are only going to display the "solved_pages" only. 
2. set a flag that will denote that aboves invariant is added ( to signal it ! ) 

As implementation this might look like the following: 
```

func dialogue_<npc_id>l() -> DynamicDialogue :
        # instantiate dialogue 
	var dynamic_dialogue = DynamicDialogue.new( )
	
	var solved_pages:Array[DynamicPage] = [
		...
	]
	# inserting entries
	dynamic_dialogue.insert_pages([],solved_pages)
	# adding invariant to disable 
	dynamic_dialogue.deactivate_undone_pages()
	# returning
	return dynamic_dialogue
``` 

---

## Testing
Please test out: 
1. talk to all npcs and solve their quest 
4. talk with the deerNPC
5. check whether the dialogue is displayed correctly