### PR TITLE
Feature/disable save management

### DIFF
--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -614,5 +614,7 @@ func save_player_state() -> Dictionary:
 # wrapper for save config save-method
 # FIXME
 func save_game():
-	Savemanager.save_config()
+	print("saving game")
+	#Savemanager.save_config()
+	
 	

--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -10,9 +10,9 @@ extends Node
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	pass
-	Savemanager.load_config()
+	#Savemanager.load_config()
 	# TODO add input to set 
-	Savemanager.select_profile("default")
+	#Savemanager.select_profile("default")
 
 # -- Signals 
 signal updated_item_inventory(new_inventory)


### PR DESCRIPTION
## motivation:

disables save management because our game does not maintain a state over session of playing it.

## What was changed/added
1. disabled loading singleton values from save file
2. disabled saving state to file

## Testing
well test it please, you should start at the same position when starting the game + the inventory is set to default too.