### PR TITLE
increased max slope of bridge player to 50

### DIFF
--- a/Arch-enemies/bridges/scenes/player.tscn
+++ b/Arch-enemies/bridges/scenes/player.tscn
@@ -274,6 +274,7 @@ radius = 6.50001
 height = 22.0
 
 [node name="CharacterBody2D" type="CharacterBody2D"]
+floor_max_angle = 0.872665
 script = ExtResource("1_uy84w")
 speed = 100.0
 jump_velocity = -250.0


### PR DESCRIPTION
## Motivation
closes #313 

## What was changed/added
I increased the maximum slope angle of the bridge player to 50 Degrees

## Testing

https://github.com/mango-gremlin/arch-enemies/assets/59502349/f459fc38-e1f4-4076-86e5-ec6112910d8a
