### PR TITLE
center the dragpreview of the animals

### DIFF
--- a/Arch-enemies/bridges/scenes/dragpreview.tscn
+++ b/Arch-enemies/bridges/scenes/dragpreview.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" path="res://bridges/script/DRAGPREVIEW.gd" id="1_dtuo0"]
 
 [node name="dragpreview" type="TextureRect"]
+top_level = true
 offset_right = 40.0
 offset_bottom = 40.0
 script = ExtResource("1_dtuo0")

--- a/Arch-enemies/bridges/script/DRAGPREVIEW.gd
+++ b/Arch-enemies/bridges/script/DRAGPREVIEW.gd
@@ -1,9 +1,12 @@
 extends TextureRect
 
+# either Deer_, Snake_, Spider_, or Squirrel_Item from the grid scene
+var animal_item
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
+	animal_item = get_parent().get_parent()
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -13,14 +16,23 @@ func _process(delta):
 	Global.currently_dragging = true
 	match tooltip_text:
 		#We have to adjust the offset based on the animal
+		# position needs to be in the middle of  a grid-square!
 		"DEER":
-			position = Vector2(global.x, global.y-40)
+			position = Vector2(global.x-15, global.y-25)
 		"SNAKE":
-			position = Vector2(global.x-44, global.y-10)
+			position = Vector2(global.x-25, global.y-5)
 		"SPIDER":
-			position = Vector2(global.x-98, global.y-10)
+			position = Vector2(global.x-5, global.y-5)
 		"SQUIRREL":
-			position = Vector2(global.x-112, global.y-20)
+			position = Vector2(global.x-5, global.y-15)
 	if Input.is_action_just_released("click"):
 		Global.currently_dragging = false
 		queue_free()
+
+# forward to grid_drag.gd
+func _can_drop_data(at_position, data):
+	return animal_item._can_drop_data(at_position, data)
+
+# forward to grid_drag.gd
+func _drop_data(at_position, data):
+	animal_item._drop_data(at_position, data)

--- a/Arch-enemies/bridges/script/grid.gd
+++ b/Arch-enemies/bridges/script/grid.gd
@@ -245,6 +245,9 @@ func update_grid(pos, data):
 			Vector2i(-1, 0), Vector2i(-1, 1)]
 			#Same for BOTTOM tiles
 			var new_bottom = [Vector2i(0, -1), Vector2i(1, -1), Vector2i(2, -1)]
+			# middle offset
+			x -= 1
+			y += 1
 			#These two loops just iterate over the grid cells we want to fill
 			for delta in range(4):
 				for epsilon in range(4):
@@ -273,6 +276,7 @@ func update_grid(pos, data):
 			var new_side = [Vector2i(-1, 0)]
 			#Same for BOTTOM tiles
 			var new_bottom = [Vector2i(0, -1), Vector2i(1, -1), Vector2i(2, -1), Vector2i(3, -1)]
+			x -= 2 # middle offset
 			for delta in range(5):
 				grid[x + delta][y] = ENTITY_TYPES.ANIMAL
 				set_cell(ACTIVE_LAYER_ID, Vector2i(x + delta, y), SNAKE_TILE_ID, Vector2i(delta, 0))

--- a/Arch-enemies/bridges/script/grid_drag.gd
+++ b/Arch-enemies/bridges/script/grid_drag.gd
@@ -123,6 +123,7 @@ func _on_grid_current_grid(current_grid):
 	grid = current_grid
 	
 func is_snake_allowed(pos):
+	pos.x -= 2 # middle offset
 	if(in_bound(pos, 5, 1)):
 		return false
 	var is_allowed = false
@@ -156,6 +157,9 @@ func is_spider_allowed(pos):
 	return is_allowed_and_free
 	
 func is_deer_allowed(pos):
+	# middle offset
+	pos.x -= 1
+	pos.y += 1
 	if(in_bound(pos, 4, 4)):
 		return false
 	var is_allowed = false 


### PR DESCRIPTION
## Motivation
closes #315

The placement of animals was based on the cursor at the lower left corner and not the dragpreview which was confusing for players.
It is nicer to have the cursor in the center of the dragpreview.

## What was changed/added
The problem with centering the cursor on the dragpreview was that `_can_drop_data()` wasn't called anymore and nothing could be placed. This was due to the preview being a different scene, not connected to our `_can_drop_data()` function.

This could be solved by adding it and also the `_drop_data()` function to `DRAGPREVIEW.gd` which is connected to the dragpreview.tscn scene. These new functions just call the old functions in `grid_drag.gd`(this is not the greatest coding but it works).

Other than that the new positions of deer and snake needed to be adjusted, because we were using different grid positions before.

## Testing


https://github.com/mango-gremlin/arch-enemies/assets/116217918/776f7693-a407-47bc-b3ee-dec154cfef89

