### PR TITLE
Fix main menu export

### DIFF
--- a/Arch-enemies/overworld/ui/main_menu/main_menu.tscn
+++ b/Arch-enemies/overworld/ui/main_menu/main_menu.tscn
@@ -109,8 +109,7 @@ offset_bottom = 523.0
 layout_mode = 2
 theme_override_constants/outline_size = 0
 theme_override_font_sizes/font_size = 56
-text = "New Game
-"
+text = "New Game"
 
 [node name="Options" type="Button" parent="VBoxContainer"]
 layout_mode = 2


### PR DESCRIPTION
## Motivation
closes #325 
While it did work in the editor, in the export version the main menu buttons were misaligned.

## What was changed/added
Delete one whitespace. 

## Testing
I'm 99.9% sure it will work, but until someone shows me how to export this game, I can't test it.
