### PR TITLE
overworld | display dialogue if quest solved and not spoken to before

### DIFF
--- a/Arch-enemies/overworld/dialogue/Dialogue.gd
+++ b/Arch-enemies/overworld/dialogue/Dialogue.gd
@@ -36,12 +36,20 @@ func in_dialogue() -> bool:
 	return is_in_dialogue
 
 func exit_dialogue():
-	is_in_dialogue = false 
-	active_dialogue = null
-	print("exiting dialogue")
+	# quest could be removed if it was solved
 	if SingletonPlayer.check_dialogue_finished(current_npc_id):
 		SingletonPlayer.remove_quest_string(current_npc_id)
-	
+	is_in_dialogue = false
+	# FIXME NUll-value 
+	active_dialogue = null
+	var quest_done:bool = SingletonPlayer.obtain_npc_quest_state(current_npc_id)
+	var spoke_to_before:bool = SingletonPlayer.npc_check_spoke_to(current_npc_id)
+	print("spoke with npc " +  str(spoke_to_before))
+	if not spoke_to_before and quest_done :
+		print("showing quest done dialogue")
+		SingletonPlayer.prepare_dialogue(current_npc_id)
+		SingletonPlayer.npc_set_spoke_to(current_npc_id,true)
+		return 
 	# hide panel
 	npc_control_instance.hide()
 

--- a/Arch-enemies/overworld/dialogue/Dialogue_Data.gd
+++ b/Arch-enemies/overworld/dialogue/Dialogue_Data.gd
@@ -9,6 +9,7 @@ var quest_done_entries: Array[Dialogue_Entry] = []
 var active_pages:Array[Dialogue_Entry] = []
 var currentEntry: int = 0
 var finished: bool = false
+var spoke_to_before:bool = false 
 var npc_name:String = ""
 
 # used to disable two dialogue options and only use the dialogue_done entries

--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -444,6 +444,12 @@ func check_dialogue_finished(npc_id:int) -> bool:
 		
 	return npc_dialogues[npc_id].finished
 
+func npc_check_spoke_to(npc_id:int) -> bool:
+	return npc_dialogues[npc_id].spoke_to_before
+
+func npc_set_spoke_to(npc_id:int, state:bool):
+	npc_dialogues[npc_id].spoke_to_before = state
+
 func obtain_dialogue(npc_id:int):
 	return npc_dialogues[npc_id]
 


### PR DESCRIPTION
## Motivation
resolves #329 

## What was changed/added
added variable to dialogue_data that tracks whether we spoke to the npc before.

Upon solving their quest before speaking to them the dialogue will be entered again ( and display the solved one ). 
It will then set this variable  to true preventing this to loop forever. 
This adds an invariant. 

## Testing
Well test the following: 
1. gather nut and fly
2. speak to squirrel and observe behavior 
3. speak to spider and observe behavior 
4. speak to snake afterwards