### PR TITLE
overworld | improve quest dialogues

### DIFF
--- a/Arch-enemies/overworld/dialogue/Dialogue.gd
+++ b/Arch-enemies/overworld/dialogue/Dialogue.gd
@@ -36,12 +36,20 @@ func in_dialogue() -> bool:
 	return is_in_dialogue
 
 func exit_dialogue():
-	is_in_dialogue = false 
-	active_dialogue = null
-	print("exiting dialogue")
+	# quest could be removed if it was solved
 	if SingletonPlayer.check_dialogue_finished(current_npc_id):
 		SingletonPlayer.remove_quest_string(current_npc_id)
-	
+	is_in_dialogue = false
+	# FIXME NUll-value 
+	active_dialogue = null
+	var quest_done:bool = SingletonPlayer.obtain_npc_quest_state(current_npc_id)
+	var spoke_to_before:bool = SingletonPlayer.npc_check_spoke_to(current_npc_id)
+	print("spoke with npc " +  str(spoke_to_before))
+	if not spoke_to_before and quest_done :
+		print("showing quest done dialogue")
+		SingletonPlayer.prepare_dialogue(current_npc_id)
+		SingletonPlayer.npc_set_spoke_to(current_npc_id,true)
+		return 
 	# hide panel
 	npc_control_instance.hide()
 

--- a/Arch-enemies/overworld/dialogue/Dialogue_Data.gd
+++ b/Arch-enemies/overworld/dialogue/Dialogue_Data.gd
@@ -9,6 +9,7 @@ var quest_done_entries: Array[Dialogue_Entry] = []
 var active_pages:Array[Dialogue_Entry] = []
 var currentEntry: int = 0
 var finished: bool = false
+var spoke_to_before:bool = false 
 var npc_name:String = ""
 
 # used to disable two dialogue options and only use the dialogue_done entries

--- a/Arch-enemies/overworld/dialogues/OverworldDialogues.gd
+++ b/Arch-enemies/overworld/dialogues/OverworldDialogues.gd
@@ -27,6 +27,7 @@ static func dialogue_snake_stefan():
 
 	]
 	var solved_pages:Array[DynamicPage] = [
+		DynamicPage.new("You give Ssssssstefan an egg.", "You", fox_portrait),
 		DynamicPage.new("Is zzat an eegg?? Oh zzat's szzoo niczze of youu! I will help you, but don't get too closzze to me or I might take a bite. I can't help it, it'szz a reflexzz.", "Ssssssstefan",snake_portrait)
 	]
 	
@@ -48,6 +49,7 @@ static func dialogue_spider_grandpa():
 	]
 	
 	var solved_pages:Array[DynamicPage] = [
+		DynamicPage.new("You give Grandfather Longlegs a huge fly.", "You", fox_portrait),
 		DynamicPage.new("Many thanks, young lad. Now that my family is cared for I will aid you on your quest.", "Grandfather Longlegs",spider_portrait)
 	]
 	
@@ -70,6 +72,7 @@ static func dialogue_squirrel_egg():
 	]
 	
 	var solved_pages:Array[DynamicPage] = [
+		DynamicPage.new("You give Esther a nut.", "You", fox_portrait),
 		DynamicPage.new("This is way better than the purple one! Ill take this one and you get the purple one.", "Esther",squirrel_portrait)
 	]
 	
@@ -100,6 +103,7 @@ static func dialogue_squirrel_ol_nutter():
 	]
 	
 	var solved_pages:Array[DynamicPage] = [
+		DynamicPage.new("You tell Ol' Nutter about some evidence you found.", "You", fox_portrait),
 		DynamicPage.new("<Excited Squeaking>...this is incredible! Now everyone will believe in the NUT! We can rise up against Big Frog! We'll join your noble cause!", "Ol' Nutter",squirrel_nutter_portrait)
 	]
 	

--- a/Arch-enemies/overworld/dialogues/OverworldDialogues.gd
+++ b/Arch-enemies/overworld/dialogues/OverworldDialogues.gd
@@ -27,7 +27,7 @@ static func dialogue_snake_stefan():
 
 	]
 	var solved_pages:Array[DynamicPage] = [
-		DynamicPage.new("You give Ssssssstefan an egg.", "You", fox_portrait),
+		DynamicPage.new("~ You give Ssssssstefan an egg. ~", "You", fox_portrait),
 		DynamicPage.new("Is zzat an eegg?? Oh zzat's szzoo niczze of youu! I will help you, but don't get too closzze to me or I might take a bite. I can't help it, it'szz a reflexzz.", "Ssssssstefan",snake_portrait)
 	]
 	
@@ -49,7 +49,7 @@ static func dialogue_spider_grandpa():
 	]
 	
 	var solved_pages:Array[DynamicPage] = [
-		DynamicPage.new("You give Grandfather Longlegs a huge fly.", "You", fox_portrait),
+		DynamicPage.new("~ You give Grandfather Longlegs a huge fly. ~", "You", fox_portrait),
 		DynamicPage.new("Many thanks, young lad. Now that my family is cared for I will aid you on your quest.", "Grandfather Longlegs",spider_portrait)
 	]
 	
@@ -72,7 +72,7 @@ static func dialogue_squirrel_egg():
 	]
 	
 	var solved_pages:Array[DynamicPage] = [
-		DynamicPage.new("You give Esther a nut.", "You", fox_portrait),
+		DynamicPage.new("~ You give Esther a nut. ~", "You", fox_portrait),
 		DynamicPage.new("This is way better than the purple one! Ill take this one and you get the purple one.", "Esther",squirrel_portrait)
 	]
 	
@@ -103,7 +103,7 @@ static func dialogue_squirrel_ol_nutter():
 	]
 	
 	var solved_pages:Array[DynamicPage] = [
-		DynamicPage.new("You tell Ol' Nutter about some evidence you found.", "You", fox_portrait),
+		DynamicPage.new("~ You tell Ol' Nutter about some evidence you found. ~", "You", fox_portrait),
 		DynamicPage.new("<Excited Squeaking>...this is incredible! Now everyone will believe in the NUT! We can rise up against Big Frog! We'll join your noble cause!", "Ol' Nutter",squirrel_nutter_portrait)
 	]
 	

--- a/Arch-enemies/singleton_scripts/singleton_player.gd
+++ b/Arch-enemies/singleton_scripts/singleton_player.gd
@@ -444,6 +444,12 @@ func check_dialogue_finished(npc_id:int) -> bool:
 		
 	return npc_dialogues[npc_id].finished
 
+func npc_check_spoke_to(npc_id:int) -> bool:
+	return npc_dialogues[npc_id].spoke_to_before
+
+func npc_set_spoke_to(npc_id:int, state:bool):
+	npc_dialogues[npc_id].spoke_to_before = state
+
 func obtain_dialogue(npc_id:int):
 	return npc_dialogues[npc_id]
 


### PR DESCRIPTION
Something went wrong with the branch and I (Kabooni) couldn't commit to it. Here's a new updated pr.

## Motivation
resolves #329 

## What was changed/added
added variable to dialogue_data that tracks whether we spoke to the npc before.

Upon solving their quest before speaking to them the dialogue will be entered again ( and display the solved one ). 
It will then set this variable  to true preventing this to loop forever. 
This adds an invariant. 

Also added new dialogue to inform the player that an item was given to the npc.

## Testing
Well test the following: 
1. gather nut and fly
2. speak to squirrel and observe behavior 
3. speak to spider and observe behavior 
4. speak to snake afterwards

The quest solved dialogue now contains an action dialogue for giving an item. E.g. for the spider:
![image](https://github.com/mango-gremlin/arch-enemies/assets/57258671/5ca6d405-aa1f-449a-955c-643859c41ad5)
