### PR TITLE
bridges | add coyote timer for jumping

### DIFF
--- a/Arch-enemies/bridges/scenes/0_TutorialLevel.tscn
+++ b/Arch-enemies/bridges/scenes/0_TutorialLevel.tscn
@@ -873,17 +873,30 @@ stream = ExtResource("1_he7ej")
 volume_db = -10.0
 autoplay = true
 
-[node name="Sound Effects" type="AudioStreamPlayer" parent="."]
-stream = ExtResource("2_de6d8")
-max_polyphony = 3
-script = ExtResource("3_h8x8j")
-
 [node name="Walking Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("4_4odb0")
 script = ExtResource("5_njj7s")
 
 [node name="Walking_Timer" type="Timer" parent="."]
 one_shot = true
+
+[node name="Coyote_Timer" type="Timer" parent="."]
+one_shot = true
+
+[node name="Sound Effects" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("2_de6d8")
+max_polyphony = 3
+script = ExtResource("3_h8x8j")
+
+[node name="goal_menu" parent="Sound Effects" instance=ExtResource("18_65aa1")]
+visible = false
+top_level = true
+offset_left = 192.0
+offset_top = 108.0
+offset_right = -221.568
+offset_bottom = -136.296
+size_flags_horizontal = 4
+size_flags_vertical = 4
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(192, 108)
@@ -1022,8 +1035,9 @@ scale = Vector2(0.5, 0.5)
 theme = ExtResource("21_ltn3j")
 text = "One Step Back"
 
-[node name="Player" parent="Grid" groups=["player"] instance=ExtResource("16_cholv")]
+[node name="Player" parent="Grid" node_paths=PackedStringArray("coyote_timer") groups=["player"] instance=ExtResource("16_cholv")]
 position = Vector2(57, 119)
+coyote_timer = NodePath("../../Coyote_Timer")
 
 [node name="world_edge_right" parent="Grid" instance=ExtResource("17_wdx7v")]
 position = Vector2(400, 40)
@@ -1032,16 +1046,6 @@ scale = Vector2(1, 10)
 [node name="world_edge_left" parent="Grid" instance=ExtResource("17_wdx7v")]
 position = Vector2(-10, 61)
 scale = Vector2(1, 10)
-
-[node name="goal_menu" parent="Grid" instance=ExtResource("18_65aa1")]
-visible = false
-top_level = true
-offset_left = 192.0
-offset_top = 108.0
-offset_right = -221.568
-offset_bottom = -136.296
-size_flags_horizontal = 4
-size_flags_vertical = 4
 
 [node name="goal" parent="Grid" instance=ExtResource("19_i2bhv")]
 position = Vector2(352, 82)

--- a/Arch-enemies/bridges/scenes/0_TutorialLevel.tscn
+++ b/Arch-enemies/bridges/scenes/0_TutorialLevel.tscn
@@ -880,9 +880,6 @@ script = ExtResource("5_njj7s")
 [node name="Walking_Timer" type="Timer" parent="."]
 one_shot = true
 
-[node name="Coyote_Timer" type="Timer" parent="."]
-one_shot = true
-
 [node name="Sound Effects" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("2_de6d8")
 max_polyphony = 3
@@ -1035,9 +1032,8 @@ scale = Vector2(0.5, 0.5)
 theme = ExtResource("21_ltn3j")
 text = "One Step Back"
 
-[node name="Player" parent="Grid" node_paths=PackedStringArray("coyote_timer") groups=["player"] instance=ExtResource("16_cholv")]
+[node name="Player" parent="Grid" groups=["player"] instance=ExtResource("16_cholv")]
 position = Vector2(57, 119)
-coyote_timer = NodePath("../../Coyote_Timer")
 
 [node name="world_edge_right" parent="Grid" instance=ExtResource("17_wdx7v")]
 position = Vector2(400, 40)

--- a/Arch-enemies/bridges/scenes/0_TutorialLevel.tscn
+++ b/Arch-enemies/bridges/scenes/0_TutorialLevel.tscn
@@ -873,17 +873,17 @@ stream = ExtResource("1_he7ej")
 volume_db = -10.0
 autoplay = true
 
+[node name="Sound Effects" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("2_de6d8")
+max_polyphony = 3
+script = ExtResource("3_h8x8j")
+
 [node name="Walking Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("4_4odb0")
 script = ExtResource("5_njj7s")
 
 [node name="Walking_Timer" type="Timer" parent="."]
 one_shot = true
-
-[node name="Sound Effects" type="AudioStreamPlayer" parent="."]
-stream = ExtResource("2_de6d8")
-max_polyphony = 3
-script = ExtResource("3_h8x8j")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(192, 108)

--- a/Arch-enemies/bridges/scenes/0_TutorialLevel.tscn
+++ b/Arch-enemies/bridges/scenes/0_TutorialLevel.tscn
@@ -885,16 +885,6 @@ stream = ExtResource("2_de6d8")
 max_polyphony = 3
 script = ExtResource("3_h8x8j")
 
-[node name="goal_menu" parent="Sound Effects" instance=ExtResource("18_65aa1")]
-visible = false
-top_level = true
-offset_left = 192.0
-offset_top = 108.0
-offset_right = -221.568
-offset_bottom = -136.296
-size_flags_horizontal = 4
-size_flags_vertical = 4
-
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(192, 108)
 zoom = Vector2(3, 3)
@@ -1042,6 +1032,16 @@ scale = Vector2(1, 10)
 [node name="world_edge_left" parent="Grid" instance=ExtResource("17_wdx7v")]
 position = Vector2(-10, 61)
 scale = Vector2(1, 10)
+
+[node name="goal_menu" parent="Grid" instance=ExtResource("18_65aa1")]
+visible = false
+top_level = true
+offset_left = 192.0
+offset_top = 108.0
+offset_right = -221.568
+offset_bottom = -136.296
+size_flags_horizontal = 4
+size_flags_vertical = 4
 
 [node name="goal" parent="Grid" instance=ExtResource("19_i2bhv")]
 position = Vector2(352, 82)

--- a/Arch-enemies/bridges/scenes/player.tscn
+++ b/Arch-enemies/bridges/scenes/player.tscn
@@ -278,7 +278,7 @@ floor_max_angle = 0.872665
 script = ExtResource("1_uy84w")
 speed = 100.0
 jump_velocity = -250.0
-coyote_frames = 8
+coyote_frames = 6
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 z_index = 2

--- a/Arch-enemies/bridges/scenes/player.tscn
+++ b/Arch-enemies/bridges/scenes/player.tscn
@@ -278,6 +278,7 @@ floor_max_angle = 0.872665
 script = ExtResource("1_uy84w")
 speed = 100.0
 jump_velocity = -250.0
+coyote_frames = 8
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 z_index = 2
@@ -290,4 +291,9 @@ position = Vector2(2, 4)
 rotation = 1.5708
 shape = SubResource("CapsuleShape2D_v713b")
 
+[node name="CoyoteJumpTimer" type="Timer" parent="."]
+wait_time = 0.001
+one_shot = true
+
 [connection signal="animation_finished" from="AnimatedSprite2D" to="." method="_on_animated_sprite_2d_animation_finished"]
+[connection signal="timeout" from="CoyoteJumpTimer" to="." method="_on_coyote_jump_timer_timeout"]

--- a/Arch-enemies/bridges/script/player.gd
+++ b/Arch-enemies/bridges/script/player.gd
@@ -29,7 +29,6 @@ func _ready():
 	start_position = self.global_position
 	parent = get_parent()
 	coyote_timer.set_wait_time(coyote_frames / 60.0)
-	print(coyote_frames / 60.0, " and ", coyote_timer.get_wait_time())
 
 func _physics_process(delta):
 	if parent.menu_mode:

--- a/Arch-enemies/bridges/script/player.gd
+++ b/Arch-enemies/bridges/script/player.gd
@@ -10,6 +10,12 @@ var direction : Vector2 = Vector2.ZERO
 var was_in_air : bool = false
 var parent
 
+# For the coyote timer
+@export var coyote_timer:Timer
+@export var coyote_frames:int = 6
+var coyote:bool = false # Whether in coyote time or not
+var last_floor:bool = false # Last frame's on-floor state
+
 # Saves if an animation is currently playing
 var animation_locked : bool = false
 
@@ -21,6 +27,7 @@ signal play_sound(sound)
 func _ready():
 	start_position = self.global_position
 	parent = get_parent()
+	coyote_timer.set_wait_time(coyote_frames / 60.0)
 
 func _physics_process(delta):
 	if parent.menu_mode:
@@ -31,6 +38,8 @@ func _physics_process(delta):
 		if velocity.y > 250:
 			animated_sprite.play("jump_fall")
 		was_in_air = true
+		if last_floor:
+			coyote = true
 	elif was_in_air == true:
 		land()
 
@@ -40,7 +49,7 @@ func _physics_process(delta):
 		return
 
 	# Handle Jump.
-	if Input.is_action_just_pressed("jump") and is_on_floor():
+	if Input.is_action_just_pressed("jump") and (is_on_floor() or coyote):
 		play_sound.emit("JUMP")
 		jump()
 
@@ -59,6 +68,8 @@ func _physics_process(delta):
 	
 	
 	move_and_slide()
+	# Store is_on_floor for the next frame
+	last_floor = is_on_floor()
 	update_animation()
 	update_facing_direction()
 

--- a/Arch-enemies/bridges/script/player.gd
+++ b/Arch-enemies/bridges/script/player.gd
@@ -9,10 +9,11 @@ var start_position : Vector2
 var direction : Vector2 = Vector2.ZERO
 var was_in_air : bool = false
 var parent
+var has_jumped:bool = false
 
 # For the coyote timer
-@export var coyote_timer:Timer
-@export var coyote_frames:int = 6
+@onready var coyote_timer:Timer = $CoyoteJumpTimer
+@export var coyote_frames:int
 var coyote:bool = false # Whether in coyote time or not
 var last_floor:bool = false # Last frame's on-floor state
 
@@ -28,18 +29,20 @@ func _ready():
 	start_position = self.global_position
 	parent = get_parent()
 	coyote_timer.set_wait_time(coyote_frames / 60.0)
+	print(coyote_frames / 60.0, " and ", coyote_timer.get_wait_time())
 
 func _physics_process(delta):
 	if parent.menu_mode:
 		return
 	# Add the gravity.
 	if not is_on_floor():
+		if last_floor:
+			coyote = true
+			coyote_timer.start()
 		velocity.y += gravity * delta
 		if velocity.y > 250:
 			animated_sprite.play("jump_fall")
 		was_in_air = true
-		if last_floor:
-			coyote = true
 	elif was_in_air == true:
 		land()
 
@@ -49,7 +52,7 @@ func _physics_process(delta):
 		return
 
 	# Handle Jump.
-	if Input.is_action_just_pressed("jump") and (is_on_floor() or coyote):
+	if Input.is_action_just_pressed("jump") and (is_on_floor() or coyote) and not has_jumped:
 		play_sound.emit("JUMP")
 		jump()
 
@@ -66,10 +69,9 @@ func _physics_process(delta):
 	else:
 		Global.walking = false
 	
-	
-	move_and_slide()
 	# Store is_on_floor for the next frame
 	last_floor = is_on_floor()
+	move_and_slide()
 	update_animation()
 	update_facing_direction()
 
@@ -105,14 +107,19 @@ func jump():
 	velocity.y = jump_velocity
 	animated_sprite.play("jump_up")
 	animation_locked = true
+	has_jumped = true
 
 func land():
 	animated_sprite.play("jump_down")
 	animation_locked = true
 	was_in_air = false
+	has_jumped = false
 
 func _on_animated_sprite_2d_animation_finished():
 	if animated_sprite.animation == "jump_down":
 		animation_locked = false
 	elif animated_sprite.animation == "jump_up":
 		animated_sprite.play("jump_fly")
+
+func _on_coyote_jump_timer_timeout():
+	coyote = false


### PR DESCRIPTION
## Motivation
closes #328

It would be nice to give the player a small grace period before falling, where jumping is still allowed.

## What was changed/added
Added a timer, which starts when falling and allows jumping once for a duration of `coyote_frames / 60`. I set the frame number to 8 but this can be changed easily in the editor.

## Testing

https://github.com/mango-gremlin/arch-enemies/assets/57258671/691ccdc9-af24-4cfd-83e3-2b8bf552f8c8

