### PR TITLE
bridges | implemented/added back button in goal menu

### DIFF
--- a/Arch-enemies/bridges/scenes/goal_menu.tscn
+++ b/Arch-enemies/bridges/scenes/goal_menu.tscn
@@ -82,5 +82,17 @@ theme = ExtResource("4_a7dfh")
 text = "Retry"
 metadata/_edit_use_anchors_ = true
 
+[node name="RetryButton" type="Button" parent="VBoxContainer/RetryButton"]
+z_index = 2
+layout_mode = 1
+anchors_preset = -1
+anchor_top = 1.25
+anchor_right = 1.0
+anchor_bottom = 2.25
+theme = ExtResource("4_a7dfh")
+text = "Back"
+metadata/_edit_use_anchors_ = true
+
 [connection signal="pressed" from="VBoxContainer/ContinueButton" to="." method="_on_continue_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/RetryButton" to="." method="_on_retry_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/RetryButton/RetryButton" to="." method="_on_back_button_pressed"]

--- a/Arch-enemies/bridges/script/goal_menu.gd
+++ b/Arch-enemies/bridges/script/goal_menu.gd
@@ -22,3 +22,11 @@ func _on_continue_button_pressed():
 	SingletonPlayer.add_bridge_connection(current_edge)
 	#SingletonPlayer.set_current_bridge_edge(null)
 	get_tree().change_scene_to_file("res://overworld/main_scene_overworld.tscn")
+
+func _on_back_button_pressed():
+	#reset everthing except the placed animals
+	var grid = get_parent()
+	grid.get_node("Player").reset_player()
+	grid.change_ui_visibility()
+	grid.reset_modes()
+	visible = false


### PR DESCRIPTION
## Motivation
closes #359 

## What was changed/added
Added a back button to the goal menu which implements the behavior described in the issue.

## Visuals

https://github.com/mango-gremlin/arch-enemies/assets/59502349/6a1bf56c-4e8a-428e-ada5-d566b80a020f