### PR TITLE
overworld | dialogue playing twice if quest solved

### DIFF
--- a/Arch-enemies/overworld/dialogue/Dialogue.gd
+++ b/Arch-enemies/overworld/dialogue/Dialogue.gd
@@ -44,11 +44,11 @@ func exit_dialogue():
 	active_dialogue = null
 	var quest_done:bool = SingletonPlayer.obtain_npc_quest_state(current_npc_id)
 	var spoke_to_before:bool = SingletonPlayer.npc_check_spoke_to(current_npc_id)
+	SingletonPlayer.npc_set_spoke_to(current_npc_id,true)
 	print("spoke with npc " +  str(spoke_to_before))
 	if not spoke_to_before and quest_done :
 		print("showing quest done dialogue")
 		SingletonPlayer.prepare_dialogue(current_npc_id)
-		SingletonPlayer.npc_set_spoke_to(current_npc_id,true)
 		return 
 	# hide panel
 	npc_control_instance.hide()


### PR DESCRIPTION
## Motivation
resolves a bug that was added after merging #352 :

Specifically one could talk to a npc, get their requirement and submit the quest. Once that was done the dialogue for solving the quest was shown twice - because the internal tracking of "spoken_to_before" was not updated on each occasion. 

## What was changed/added
To resolve the internal state is now updated upon exiting the dialogue - every time. 


## Testing
As in #352 you can try the following:
**solve quest without prior talk**: 
1. gather item for one npc 
2. talk to npc and observe whether the quest done dialogue is shown after the initial dialogue

**solve quest with prior talking**: 

1. talk to npc 
2. gather their requirement 
3. talk to them again and observe the quest_done_dialogue to show up only once! 
---
