### PR TITLE
overworld | collision size and pos of npc interaction determined from sprite

### DIFF
--- a/Arch-enemies/overworld/entities/interaction_overworld/npc_interaction.gd
+++ b/Arch-enemies/overworld/entities/interaction_overworld/npc_interaction.gd
@@ -144,20 +144,29 @@ func obtain_required_item() -> Item.ItemType:
 func set_npc_sprite():
 	# initialize reference
 	var referenced_sprite:Sprite2D = $Sprite2D
+	# collision shape for size change
+	var npc_collision = $StaticBody2D/CollisionShape2D
 	
 	if npc_special_sprite != null:
 		referenced_sprite.texture = npc_special_sprite
+		npc_collision.position = Vector2(0,0)
+		npc_collision.scale = Vector2(0.5,0.5)
 		return
 	var path_to_sprite:String 
 	match npc_animal_type:
 		Animal.AnimalType.SNAKE: 
 			path_to_sprite = "res://assets/art/characters/snek.png"
+			npc_collision.position = Vector2(0,-1)
+			npc_collision.scale = Vector2(2,2)
 		Animal.AnimalType.DEER:
 			path_to_sprite = "res://assets/art/characters/deer.png"
+			npc_collision.position = Vector2(-6,4)
+			npc_collision.scale = Vector2(2,2)
 		Animal.AnimalType.SQUIRREL: 
 			path_to_sprite = "res://assets/art/characters/squirrel.png"
 		Animal.AnimalType.SPIDER:
 			path_to_sprite = "res://assets/art/characters/spider.png"
+			npc_collision.position = Vector2(0,0)
 	# loading texture 
 	var npc_sprite:Texture2D = load(path_to_sprite)
 	referenced_sprite.texture = npc_sprite

--- a/Arch-enemies/overworld/entities/interaction_overworld/npc_interaction.tscn
+++ b/Arch-enemies/overworld/entities/interaction_overworld/npc_interaction.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://drn1loe1wknbq"]
+[gd_scene load_steps=16 format=3 uid="uid://drn1loe1wknbq"]
 
 [ext_resource type="Script" path="res://overworld/entities/interaction_overworld/npc_interaction.gd" id="1_cdxnf"]
 [ext_resource type="Texture2D" uid="uid://xd2wfewwwcqc" path="res://assets/art/characters/squirrel.png" id="2_83185"]
@@ -75,6 +75,9 @@ animations = [{
 "speed": 5.0
 }]
 
+[sub_resource type="CircleShape2D" id="CircleShape2D_pbodm"]
+radius = 7.0
+
 [node name="NpcInteraction" type="Node2D"]
 y_sort_enabled = true
 script = ExtResource("1_cdxnf")
@@ -105,3 +108,9 @@ position = Vector2(0, -20)
 sprite_frames = SubResource("SpriteFrames_dm71c")
 animation = &"npc_indication"
 frame_progress = 0.809533
+
+[node name="StaticBody2D" type="StaticBody2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
+position = Vector2(0, 3)
+shape = SubResource("CircleShape2D_pbodm")

--- a/Arch-enemies/overworld/scenes/world.tscn
+++ b/Arch-enemies/overworld/scenes/world.tscn
@@ -59,6 +59,7 @@ margins = Vector2i(4, 0)
 5:0/0 = 0
 5:0/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 5:0/0/physics_layer_0/angular_velocity = 0.0
+5:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-1.94894, -4.11443, -0.925254, -5.25623, 4.11443, -5.17749, 7.028, -1.55522, 6.00431, 1.75208, -0.807137, 2.06706, -1.8702, 0.925254)
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_w0ol6"]
 texture = ExtResource("4_itohn")


### PR DESCRIPTION
## Motivation
closes #365 

NPCs had no collision as of the first playtest.

## What was changed/added
Added a collision shape (circle), depending on the npc sprite, the position and size of it is changed to approximate the sprite.
Also added collision to the frogs on the frog island (these are just the frog hazard tile)

## Testing

https://github.com/mango-gremlin/arch-enemies/assets/104830903/0a295b68-9451-4411-aaac-d06136e501bd


